### PR TITLE
Simplify callable 2

### DIFF
--- a/include/kyosu/functions/airy.hpp
+++ b/include/kyosu/functions/airy.hpp
@@ -6,7 +6,6 @@
 */
 //======================================================================================================================
 #pragma once
-#include "eve/traits/as_logical.hpp"
 #include <kyosu/details/callable.hpp>
 #include <kyosu/constants/wrapped.hpp>
 #include <kyosu/functions/cyl_bessel_i.hpp>
@@ -18,7 +17,26 @@ namespace kyosu
   {
     template<concepts::cayley_dickson Z>
     KYOSU_FORCEINLINE constexpr kumi::tuple<Z, Z>operator()(Z const& z) const noexcept
-    { return KYOSU_CALL(z); }
+    {     using u_t = eve::underlying_type_t<Z>;
+      if constexpr(concepts::complex<Z>)
+      {
+        auto zet = [](auto z) {
+          using u_t = eve::underlying_type_t<Z>;
+          auto sqz = sqrt(z);
+          auto zeta = (pow(z, u_t(1.5))*2)/3;
+          return kumi::tuple{sqz/kyosu::sqrt_3(as(z)), zeta};
+        };
+
+        auto [sqzo3, zeta] = zet(z);
+        auto ip = cyl_bessel_i(eve::third(as<u_t>()), zeta);
+        auto im = cyl_bessel_i(-eve::third(as<u_t>()), zeta);
+        return kumi::tuple{inv_pi(as<u_t>())*sqzo3*(im-ip),  sqzo3*(ip+im)};
+      }
+      else
+      {
+        return _::cayley_extend2(*this, z);
+      }
+    }
 
     template<concepts::real V>
     KYOSU_FORCEINLINE constexpr kumi::tuple<V, V> operator()(V v) const noexcept
@@ -69,17 +87,4 @@ namespace kyosu
 //======================================================================================================================
 //! @}
 //======================================================================================================================
-}
-
-namespace kyosu::_
-{
-  template<typename Z, eve::callable_options O>
-  KYOSU_FORCEINLINE constexpr auto airy_(KYOSU_DELAY(), O const&, Z z) noexcept
-  {
-    using u_t = eve::underlying_type_t<Z>;
-    auto [sqzo3, zeta] = zet(z);
-    auto ip = cyl_bessel_i(eve::third(as<u_t>()), zeta);
-    auto im = cyl_bessel_i(-eve::third(as<u_t>()), zeta);
-    return kumi::tuple{inv_pi(as<u_t>())*sqzo3*(im-ip),  sqzo3*(ip+im)};
-  }
 }

--- a/include/kyosu/functions/airy_ai.hpp
+++ b/include/kyosu/functions/airy_ai.hpp
@@ -20,7 +20,7 @@ namespace kyosu
       if constexpr(kyosu::concepts::complex<Z> )
         return _::ai(z);
       else
-        return kyosu::_::cayley_extend(*this, z);
+        return _::cayley_extend(*this, z);
     }
 
     template<concepts::real V>

--- a/include/kyosu/functions/airy_bi.hpp
+++ b/include/kyosu/functions/airy_bi.hpp
@@ -20,7 +20,7 @@ namespace kyosu
       if constexpr(kyosu::concepts::complex<Z> )
         return _::bi(z);
       else
-        return kyosu::_::cayley_extend(*this, z);
+        return _::cayley_extend(*this, z);
     }
 
     template<concepts::real V>

--- a/include/kyosu/functions/atan.hpp
+++ b/include/kyosu/functions/atan.hpp
@@ -28,7 +28,7 @@ namespace kyosu
       }
       else
       {
-        return kyosu::_::cayley_extend(*this, z);
+        return _::cayley_extend(*this, z);
       }
     }
 

--- a/include/kyosu/functions/cos.hpp
+++ b/include/kyosu/functions/cos.hpp
@@ -21,7 +21,7 @@ namespace kyosu
       if constexpr(concepts::complex<Z> )
         return cosh(muli(z));
       else
-        return kyosu::_::cayley_extend(*this, z);
+        return _::cayley_extend(*this, z);
     }
 
     template<concepts::real V>

--- a/include/kyosu/functions/cosh.hpp
+++ b/include/kyosu/functions/cosh.hpp
@@ -38,7 +38,7 @@ namespace kyosu
       }
       else
       {
-        return kyosu::_::cayley_extend(*this, z);
+        return _::cayley_extend(*this, z);
       }
     }
 

--- a/include/kyosu/functions/cospi.hpp
+++ b/include/kyosu/functions/cospi.hpp
@@ -37,7 +37,7 @@ namespace kyosu
       }
       else
       {
-        return kyosu::_::cayley_extend(*this, z);
+        return _::cayley_extend(*this, z);
       }
     }
 

--- a/include/kyosu/functions/cot.hpp
+++ b/include/kyosu/functions/cot.hpp
@@ -25,7 +25,7 @@ namespace kyosu
       }
       else
       {
-        return kyosu::_::cayley_extend(*this, z);
+        return _::cayley_extend(*this, z);
       }
     }
 

--- a/include/kyosu/functions/coth.hpp
+++ b/include/kyosu/functions/coth.hpp
@@ -24,10 +24,10 @@ namespace kyosu
       }
       else
       {
-        return kyosu::_::cayley_extend(*this, z);
+        return _::cayley_extend(*this, z);
       }
     }
-    
+
     template<concepts::real V>
     KYOSU_FORCEINLINE constexpr V operator()(V v) const noexcept
     { return eve::coth(v); }
@@ -74,4 +74,3 @@ namespace kyosu
 //! @}
 //======================================================================================================================
 }
-

--- a/include/kyosu/functions/cotpi.hpp
+++ b/include/kyosu/functions/cotpi.hpp
@@ -28,7 +28,7 @@ namespace kyosu
       }
       else
       {
-        return kyosu::_::cayley_extend(*this, z);
+        return _::cayley_extend(*this, z);
       }
     }
 

--- a/include/kyosu/functions/cyl_bessel_h1.hpp
+++ b/include/kyosu/functions/cyl_bessel_h1.hpp
@@ -26,7 +26,7 @@ namespace kyosu
 
     template<concepts::real NU, concepts::real V>
     KYOSU_FORCEINLINE constexpr complex_t<V> operator()(NU v, V z) const noexcept
-    { return KYOSU_CALL(v, complex(z)); }
+    { return (*this)(v, complex(z)); }
 
     KYOSU_CALLABLE_OBJECT(cyl_bessel_h1_t, cyl_bessel_h1_);
   };

--- a/include/kyosu/functions/cyl_bessel_h1.hpp
+++ b/include/kyosu/functions/cyl_bessel_h1.hpp
@@ -17,7 +17,12 @@ namespace kyosu
   {
     template<concepts::real NU, concepts::cayley_dickson Z>
     KYOSU_FORCEINLINE constexpr Z operator()(NU v, Z const& z) const noexcept
-    { return KYOSU_CALL(v, z); }
+    {
+      if constexpr(concepts::complex<Z> )
+        return _::cb_h1r(v, z);
+      else
+        return cayley_extend_rev(*this, v, z);
+    }
 
     template<concepts::real NU, concepts::real V>
     KYOSU_FORCEINLINE constexpr complex_t<V> operator()(NU v, V z) const noexcept
@@ -79,21 +84,4 @@ namespace kyosu
 //======================================================================================================================
 //! @}
 //======================================================================================================================
-}
-
-namespace kyosu::_
-{
-
-  template<typename NU, typename Z, eve::callable_options O>
-  KYOSU_FORCEINLINE constexpr auto cyl_bessel_h1_(KYOSU_DELAY(), O const&, NU v, Z z) noexcept
-  {
-    if constexpr(concepts::complex<Z> )
-    {
-      return cb_h1r(v, z);
-    }
-    else
-    {
-      return cayley_extend_rev(cyl_bessel_h1, v, z);
-    }
-  }
 }

--- a/include/kyosu/functions/cyl_bessel_h12.hpp
+++ b/include/kyosu/functions/cyl_bessel_h12.hpp
@@ -20,7 +20,7 @@ namespace kyosu
       KYOSU_FORCEINLINE constexpr auto  operator()(NU const& v, Z const & z,
                                                    std::span<Z, S> h1s, std::span<Z, S> h2s) const noexcept
     {   return _::cb_h12r(v, z, h1s, h2s); }
-
+    
     template<concepts::real NU, concepts::cayley_dickson Z>
     requires(eve::scalar_value<NU> && (concepts::real<Z> || concepts::cayley_dickson<Z>))
       KYOSU_FORCEINLINE constexpr auto  operator()(NU const& v, Z const & z) const noexcept
@@ -35,7 +35,7 @@ namespace kyosu
       else
         return caley_extend_rev2(*this, v, z);
     }
-
+    
     KYOSU_CALLABLE_OBJECT(cyl_bessel_h12_t, cyl_bessel_h12_);
   };
 

--- a/include/kyosu/functions/cyl_bessel_h12.hpp
+++ b/include/kyosu/functions/cyl_bessel_h12.hpp
@@ -18,16 +18,26 @@ namespace kyosu
     template<concepts::real NU, typename Z, std::size_t S>
     requires(concepts::real<Z> || concepts::cayley_dickson<Z>)
       KYOSU_FORCEINLINE constexpr auto  operator()(NU const& v, Z const & z,
-                                                   std::span<Z, S> js, std::span<Z, S> ys) const noexcept
-    { return KYOSU_CALL(v,z,js,ys); }
+                                                   std::span<Z, S> h1s, std::span<Z, S> h2s) const noexcept
+    {   return _::cb_h12r(v, z, h1s, h2s); }
 
     template<concepts::real NU, concepts::cayley_dickson Z>
     requires(eve::scalar_value<NU> && (concepts::real<Z> || concepts::cayley_dickson<Z>))
       KYOSU_FORCEINLINE constexpr auto  operator()(NU const& v, Z const & z) const noexcept
-    { return KYOSU_CALL(v,z); }
+    {
+      if constexpr(concepts::complex<Z> )
+      {
+        auto doit = [v, z](auto h1s, auto h2s){
+          return _::cb_h12r(v, z, h1s, h2s);
+        };
+        return with_alloca<Z>(eve::abs(v)+1, doit);
+      }
+      else
+        return caley_extend_rev2(*this, v, z);
+    }
 
     KYOSU_CALLABLE_OBJECT(cyl_bessel_h12_t, cyl_bessel_h12_);
-};
+  };
 
 //======================================================================================================================
 //! @addtogroup functions
@@ -80,31 +90,4 @@ namespace kyosu
 //======================================================================================================================
 //! @}
 //======================================================================================================================
-}
-
-namespace kyosu::_
-{
-
-  template<typename N, typename Z, std::size_t S, eve::callable_options O>
-  KYOSU_FORCEINLINE constexpr auto cyl_bessel_h12_(KYOSU_DELAY(), O const&, N n, Z z
-                                                 , std::span<Z, S> h1s, std::span<Z, S> h2s) noexcept
-  {
-    return cb_h12r(n, z, h1s, h2s);
-  }
-
-  template<typename N, typename Z, eve::callable_options O>
-  KYOSU_FORCEINLINE constexpr auto cyl_bessel_h12_(KYOSU_DELAY(), O const&, N n, Z z) noexcept
-  {
-    if constexpr(concepts::complex<Z> )
-    {
-      auto doit = [n, z](auto h1s, auto h2s){
-        return cb_h12r(n, z, h1s, h2s);
-      };
-      return with_alloca<Z>(eve::abs(n)+1, doit);
-    }
-    else
-    {
-      return caley_extend_rev2(cyl_bessel_h12, n, z);
-    }
-  }
 }

--- a/include/kyosu/functions/cyl_bessel_h12n.hpp
+++ b/include/kyosu/functions/cyl_bessel_h12n.hpp
@@ -17,13 +17,25 @@ namespace kyosu
   {
     template<eve::integral_scalar_value Z0, typename Z1, std::size_t S>
     requires(concepts::real<Z1> || concepts::cayley_dickson<Z1>)
-      KYOSU_FORCEINLINE constexpr auto  operator()(Z0 const& z0, Z1 const & z1, std::span<Z1, S> js, std::span<Z1, S> ys) const noexcept
-    { return KYOSU_CALL(z0,z1,js,ys); }
+      KYOSU_FORCEINLINE constexpr auto  operator()(Z0 const& n, Z1 const & z, std::span<Z1, S> h1s, std::span<Z1, S> h2s) const noexcept
+    { return _::cb_h12n(n, z, h1s, h2s); }
 
     template<eve::integral_scalar_value Z0, typename Z1>
     requires(concepts::real<Z1> || concepts::cayley_dickson<Z1>)
-      KYOSU_FORCEINLINE constexpr auto  operator()(Z0 const& z0, Z1 const & z1) const noexcept
-    { return KYOSU_CALL(z0,z1); }
+      KYOSU_FORCEINLINE constexpr auto  operator()(Z0 const& n, Z1 const & z) const noexcept
+    {
+      if constexpr(concepts::complex<Z1> )
+      {
+        auto doit = [n, z](auto h1s, auto h2s){
+          return _::cb_h12n(n, z, h1s, h2s);
+        };
+        return with_alloca<Z1>(eve::abs(n)+1, doit);
+      }
+      else
+      {
+        return caley_extend_rev2(*this, n, z);
+      }
+    }
 
     KYOSU_CALLABLE_OBJECT(cyl_bessel_h12n_t, cyl_bessel_h12n_);
 };
@@ -72,31 +84,4 @@ namespace kyosu
 //======================================================================================================================
 //! @}
 //======================================================================================================================
-}
-
-namespace kyosu::_
-{
-
-  template<typename N, typename Z, std::size_t S, eve::callable_options O>
-  KYOSU_FORCEINLINE constexpr auto cyl_bessel_h12n_(KYOSU_DELAY(), O const&, N n, Z z
-                                                 , std::span<Z, S> h1s, std::span<Z, S> h2s) noexcept
-  {
-    return cb_h12n(n, z, h1s, h2s);
-  }
-
-  template<typename N, typename Z, eve::callable_options O>
-  KYOSU_FORCEINLINE constexpr auto cyl_bessel_h12n_(KYOSU_DELAY(), O const&, N n, Z z) noexcept
-  {
-    if constexpr(concepts::complex<Z> )
-    {
-      auto doit = [n, z](auto h1s, auto h2s){
-        return cb_h12n(n, z, h1s, h2s);
-      };
-      return with_alloca<Z>(eve::abs(n)+1, doit);
-    }
-    else
-    {
-      return caley_extend_rev2(cyl_bessel_h12n, n, z);
-    }
-  }
 }

--- a/include/kyosu/functions/cyl_bessel_h12r.hpp
+++ b/include/kyosu/functions/cyl_bessel_h12r.hpp
@@ -18,13 +18,25 @@ namespace kyosu
     template<concepts::real NU, typename Z, std::size_t S>
     requires(concepts::real<Z> || concepts::cayley_dickson<Z>)
       KYOSU_FORCEINLINE constexpr auto  operator()(NU const& v, Z const & z,
-                                                   std::span<Z, S> js, std::span<Z, S> ys) const noexcept
-    { return KYOSU_CALL(v,z,js,ys); }
+                                                   std::span<Z, S> h1s, std::span<Z, S> h2s) const noexcept
+    {  return _::cb_h12r(v, z, h1s, h2s); }
 
     template<concepts::real NU, concepts::cayley_dickson Z>
     requires(eve::scalar_value<NU> && (concepts::real<Z> || concepts::cayley_dickson<Z>))
       KYOSU_FORCEINLINE constexpr auto  operator()(NU const& v, Z const & z) const noexcept
-    { return KYOSU_CALL(v,z); }
+    {
+      if constexpr(concepts::complex<Z> )
+      {
+        auto doit = [n, z](auto h1s, auto h2s){
+          return _::cb_h12r(n, z, h1s, h2s);
+        };
+        return with_alloca<Z>(eve::abs(n)+1, doit);
+      }
+      else
+      {
+        return caley_extend_rev2(*this, n, z);
+      }
+    }
 
     KYOSU_CALLABLE_OBJECT(cyl_bessel_h12r_t, cyl_bessel_h12r_);
 };
@@ -73,31 +85,4 @@ namespace kyosu
 //======================================================================================================================
 //! @}
 //======================================================================================================================
-}
-
-namespace kyosu::_
-{
-
-  template<typename N, typename Z, std::size_t S, eve::callable_options O>
-  KYOSU_FORCEINLINE constexpr auto cyl_bessel_h12r_(KYOSU_DELAY(), O const&, N n, Z z
-                                                 , std::span<Z, S> h1s, std::span<Z, S> h2s) noexcept
-  {
-    return cb_h12r(n, z, h1s, h2s);
-  }
-
-  template<typename N, typename Z, eve::callable_options O>
-  KYOSU_FORCEINLINE constexpr auto cyl_bessel_h12r_(KYOSU_DELAY(), O const&, N n, Z z) noexcept
-  {
-    if constexpr(concepts::complex<Z> )
-    {
-      auto doit = [n, z](auto h1s, auto h2s){
-        return cb_h12r(n, z, h1s, h2s);
-      };
-      return with_alloca<Z>(eve::abs(n)+1, doit);
-    }
-    else
-    {
-      return caley_extend_rev2(cyl_bessel_h12r, n, z);
-    }
-  }
 }

--- a/include/kyosu/functions/cyl_bessel_h1_0.hpp
+++ b/include/kyosu/functions/cyl_bessel_h1_0.hpp
@@ -16,7 +16,12 @@ namespace kyosu
   {
     template<concepts::cayley_dickson Z>
     KYOSU_FORCEINLINE constexpr Z operator()(Z const& z) const noexcept
-    { return KYOSU_CALL(z); }
+    {
+      if constexpr(concepts::complex<Z>)
+        return _::cb_h1_0(z);
+      else
+        return _::cayley_extend(*this, z);
+    }
 
     template<concepts::real V>
     KYOSU_FORCEINLINE constexpr complex_t<V> operator()(V v) const noexcept
@@ -61,20 +66,4 @@ namespace kyosu
 //======================================================================================================================
 //! @}
 //======================================================================================================================
-}
-
-namespace kyosu::_
-{
-  template<typename Z, eve::callable_options O>
-  KYOSU_FORCEINLINE constexpr auto cyl_bessel_h1_0_(KYOSU_DELAY(), O const&, Z z) noexcept
-  {
-    if constexpr(concepts::complex<Z>)
-    {
-      return  cb_h1_0(z); //cyl_bessel_j0(z)+muli(cyl_bessel_y0(z));
-    }
-    else
-    {
-      return cayley_extend(cyl_bessel_h1_0, z);
-    }
-  }
 }

--- a/include/kyosu/functions/cyl_bessel_h1_1.hpp
+++ b/include/kyosu/functions/cyl_bessel_h1_1.hpp
@@ -16,7 +16,12 @@ namespace kyosu
   {
     template<concepts::cayley_dickson Z>
     KYOSU_FORCEINLINE constexpr Z operator()(Z const& z) const noexcept
-    { return KYOSU_CALL(z); }
+    {
+      if constexpr(concepts::complex<Z>)
+        return  cyl_bessel_j1(z)+muli(cyl_bessel_y1(z));
+      else
+        return _::cayley_extend(*this, z);
+    }
 
     template<concepts::real V>
     KYOSU_FORCEINLINE constexpr complex_t<V> operator()(V v) const noexcept
@@ -61,20 +66,4 @@ namespace kyosu
 //======================================================================================================================
 //! @}
 //======================================================================================================================
-}
-
-namespace kyosu::_
-{
-  template<typename Z, eve::callable_options O>
-  KYOSU_FORCEINLINE constexpr auto cyl_bessel_h1_1_(KYOSU_DELAY(), O const&, Z z) noexcept
-  {
-    if constexpr(concepts::complex<Z>)
-    {
-      return  cyl_bessel_j1(z)+muli(cyl_bessel_y1(z));
-    }
-    else
-    {
-      return cayley_extend(cyl_bessel_h1_1, z);
-    }
-  }
 }

--- a/include/kyosu/functions/cyl_bessel_h1n.hpp
+++ b/include/kyosu/functions/cyl_bessel_h1n.hpp
@@ -15,13 +15,20 @@ namespace kyosu
   template<typename Options>
   struct cyl_bessel_h1n_t : eve::strict_elementwise_callable<cyl_bessel_h1n_t, Options>
   {
-    template<eve::integral_scalar_value Z0, concepts::cayley_dickson Z1>
-    KYOSU_FORCEINLINE constexpr auto  operator()(Z0 const& z0, Z1 const & z1) const noexcept
-    { return KYOSU_CALL(z0,z1); }
+    template<eve::integral_scalar_value N, concepts::cayley_dickson Z>
+    KYOSU_FORCEINLINE constexpr auto  operator()(N const& n, Z const & z) const noexcept
+    {
+      if constexpr(concepts::complex<Z> )
+        return _::cb_jn(n, z)+muli(kyosu::cyl_bessel_yn(n, z));
+      else
+        return _::cayley_extend_rev(*this, n, z);
+    }
 
     template<eve::integral_scalar_value V0, concepts::real V1>
-    KYOSU_FORCEINLINE constexpr auto operator()(V0 v0, V1 v1) const noexcept
-    { return KYOSU_CALL(v0,v1); }
+    KYOSU_FORCEINLINE constexpr auto operator()(V0 n, V1 z) const noexcept
+    {
+      return eve::cyl_bessel_jn(n, z)+muli(eve::cyl_bessel_yn(n, z));;
+    }
 
     KYOSU_CALLABLE_OBJECT(cyl_bessel_h1n_t, cyl_bessel_h1n_);
 };
@@ -63,20 +70,4 @@ namespace kyosu
 //======================================================================================================================
 //! @}
 //======================================================================================================================
-}
-
-namespace kyosu::_
-{
-  template<typename N, typename Z, eve::callable_options O>
-  KYOSU_FORCEINLINE constexpr auto cyl_bessel_h1n_(KYOSU_DELAY(), O const&, N n, Z z) noexcept
-  {
-    if constexpr(concepts::complex<Z> )
-    {
-      return cb_jn(n, z)+muli(cyl_bessel_yn(n, z));
-    }
-    else
-    {
-      return cayley_extend_rev(cyl_bessel_h1n, n, z);
-    }
-  }
 }

--- a/include/kyosu/functions/cyl_bessel_h2.hpp
+++ b/include/kyosu/functions/cyl_bessel_h2.hpp
@@ -30,7 +30,7 @@ namespace kyosu
 
     template<concepts::real NU, concepts::real V>
     KYOSU_FORCEINLINE constexpr complex_t<V> operator()(NU v, V z) const noexcept
-    { return KYOSU_CALL(v, complex(z)); }
+    { return (*this)(v, complex(z)); }
 
     KYOSU_CALLABLE_OBJECT(cyl_bessel_h2_t, cyl_bessel_h2_);
 };

--- a/include/kyosu/functions/cyl_bessel_h2.hpp
+++ b/include/kyosu/functions/cyl_bessel_h2.hpp
@@ -16,7 +16,17 @@ namespace kyosu
   {
     template<concepts::real NU, concepts::cayley_dickson Z>
     KYOSU_FORCEINLINE constexpr Z operator()(NU v, Z const& z) const noexcept
-    { return KYOSU_CALL(v, z); }
+    {
+
+      if constexpr(concepts::complex<Z> )
+      {
+        return _::cb_h2r(v, z);
+      }
+      else
+      {
+        return _::cayley_extend_rev(*this, v, z);
+      }
+    }
 
     template<concepts::real NU, concepts::real V>
     KYOSU_FORCEINLINE constexpr complex_t<V> operator()(NU v, V z) const noexcept
@@ -78,20 +88,4 @@ namespace kyosu
 //======================================================================================================================
 //! @}
 //======================================================================================================================
-}
-
-namespace kyosu::_
-{
-  template<typename NU, typename Z, eve::callable_options O>
-  KYOSU_FORCEINLINE constexpr auto cyl_bessel_h2_(KYOSU_DELAY(), O const&, NU v, Z z) noexcept
-  {
-    if constexpr(concepts::complex<Z> )
-    {
-      return cb_h2r(v, z);
-    }
-    else
-    {
-      return cayley_extend_rev(cyl_bessel_h1, v, z);
-    }
-  }
 }

--- a/include/kyosu/functions/cyl_bessel_h2_0.hpp
+++ b/include/kyosu/functions/cyl_bessel_h2_0.hpp
@@ -16,7 +16,12 @@ namespace kyosu
   {
     template<concepts::cayley_dickson Z>
     KYOSU_FORCEINLINE constexpr Z operator()(Z const& z) const noexcept
-    { return KYOSU_CALL(z); }
+    {
+      if constexpr(concepts::complex<Z>)
+        return _::cb_h2_0(z);
+      else
+        return _::cayley_extend(*this, z);
+    }
 
     template<concepts::real V>
     KYOSU_FORCEINLINE constexpr complex_t<V> operator()(V v) const noexcept
@@ -61,20 +66,4 @@ namespace kyosu
 //======================================================================================================================
 //! @}
 //======================================================================================================================
-}
-
-namespace kyosu::_
-{
-  template<typename Z, eve::callable_options O>
-  KYOSU_FORCEINLINE constexpr auto cyl_bessel_h2_0_(KYOSU_DELAY(), O const&, Z z) noexcept
-  {
-    if constexpr(concepts::complex<Z>)
-    {
-      return cb_h2_0(z);
-    }
-    else
-    {
-      return cayley_extend(cyl_bessel_h2_0, z);
-    }
-  }
 }

--- a/include/kyosu/functions/cyl_bessel_h2_1.hpp
+++ b/include/kyosu/functions/cyl_bessel_h2_1.hpp
@@ -16,7 +16,16 @@ namespace kyosu
   {
     template<concepts::cayley_dickson Z>
     KYOSU_FORCEINLINE constexpr Z operator()(Z const& z) const noexcept
-    { return KYOSU_CALL(z); }
+    {
+      if constexpr(concepts::complex<Z>)
+      {
+        return  cyl_bessel_j1(z)-muli(cyl_bessel_y1(z));
+      }
+      else
+      {
+        return _::cayley_extend(*this, z);
+      }
+    }
 
     template<concepts::real V>
     KYOSU_FORCEINLINE constexpr complex_t<V> operator()(V v) const noexcept
@@ -61,20 +70,4 @@ namespace kyosu
 //======================================================================================================================
 //! @}
 //======================================================================================================================
-}
-
-namespace kyosu::_
-{
-  template<typename Z, eve::callable_options O>
-  KYOSU_FORCEINLINE constexpr auto cyl_bessel_h2_1_(KYOSU_DELAY(), O const&, Z z) noexcept
-  {
-    if constexpr(concepts::complex<Z>)
-    {
-      return  cyl_bessel_j1(z)-muli(cyl_bessel_y1(z));
-    }
-    else
-    {
-      return cayley_extend(cyl_bessel_h2_1, z);
-    }
-  }
 }

--- a/include/kyosu/functions/cyl_bessel_h2n.hpp
+++ b/include/kyosu/functions/cyl_bessel_h2n.hpp
@@ -15,14 +15,20 @@ namespace kyosu
   template<typename Options>
   struct cyl_bessel_h2n_t : eve::strict_elementwise_callable<cyl_bessel_h2n_t, Options>
   {
-    template<typename Z0, typename Z1>
-    requires(concepts::cayley_dickson<Z0> || concepts::cayley_dickson<Z1>)
-    KYOSU_FORCEINLINE constexpr auto  operator()(Z0 const& z0, Z1 const & z1) const noexcept
-    { return KYOSU_CALL(z0,z1); }
+    template<eve::integral_scalar_value N, concepts::cayley_dickson Z>
+    KYOSU_FORCEINLINE constexpr auto  operator()(N const& n, Z const & z) const noexcept
+    {
+      if constexpr(concepts::complex<Z> )
+        return cyl_bessel_jn(n, z)-muli(cyl_bessel_yn(n, z));
+      else
+        return _::cayley_extend_rev(*this, n, z);
+    }
 
-    template<concepts::real V0, concepts::real V1>
-    KYOSU_FORCEINLINE constexpr complex_t<V1> operator()(V0 v0, V1 v1) const noexcept
-    { return KYOSU_CALL(v0,v1); }
+    template<eve::integral_scalar_value N, concepts::real V>
+    KYOSU_FORCEINLINE constexpr complex_t<V> operator()(N n, V z) const noexcept
+    {
+      return eve::cyl_bessel_jn(n, z)-muli(eve::cyl_bessel_yn(n, z));
+    }
 
     KYOSU_CALLABLE_OBJECT(cyl_bessel_h2n_t, cyl_bessel_h2n_);
 };
@@ -64,20 +70,4 @@ namespace kyosu
 //======================================================================================================================
 //! @}
 //======================================================================================================================
-}
-
-namespace kyosu::_
-{
-  template<typename N, typename Z, eve::callable_options O>
-  KYOSU_FORCEINLINE constexpr auto cyl_bessel_h2n_(KYOSU_DELAY(), O const&, N n, Z z) noexcept
-  {
-    if constexpr(concepts::complex<Z> )
-    {
-      return cyl_bessel_jn(n, z)-muli(cyl_bessel_yn(n, z));
-    }
-    else
-    {
-      return cayley_extend_rev(cyl_bessel_h1n, n, z);
-    }
-  }
 }

--- a/include/kyosu/functions/cyl_bessel_i.hpp
+++ b/include/kyosu/functions/cyl_bessel_i.hpp
@@ -35,7 +35,7 @@ namespace kyosu
 
     template<concepts::real NU, concepts::real V>
     KYOSU_FORCEINLINE constexpr V operator()(NU nu, V v) const noexcept
-    { return  KYOSU_CALL(nu, complex(v)); }
+    { return  (*this)(nu, complex(v)); }
 
     KYOSU_CALLABLE_OBJECT(cyl_bessel_i_t, cyl_bessel_i_);
 };

--- a/include/kyosu/functions/cyl_bessel_i.hpp
+++ b/include/kyosu/functions/cyl_bessel_i.hpp
@@ -16,13 +16,22 @@ namespace kyosu
   {
     template<concepts::real NU, typename Z, std::size_t S>
     requires(concepts::real<Z> || concepts::cayley_dickson<Z>)
-      KYOSU_FORCEINLINE constexpr auto  operator()(NU const& nu, Z const & z, std::span<Z, S> js) const noexcept
-    { return KYOSU_CALL(nu,z,js); }
+      KYOSU_FORCEINLINE constexpr auto  operator()(NU const& v, Z const & z, std::span<Z, S> is) const noexcept
+    {   return cb_ir(v, z, is); }
 
     template<concepts::real NU, concepts::cayley_dickson Z>
     requires(eve::scalar_value<NU>)
-    KYOSU_FORCEINLINE constexpr Z operator()(NU nu, Z const& z) const noexcept
-    { return KYOSU_CALL(nu, z); }
+    KYOSU_FORCEINLINE constexpr Z operator()(NU v, Z const& z) const noexcept
+    {
+      if constexpr(concepts::complex<Z> )
+      {
+        return _::cb_ir(v, z);
+      }
+      else
+      {
+        return _::cayley_extend_rev(*this, v, z);
+      }
+    }
 
     template<concepts::real NU, concepts::real V>
     KYOSU_FORCEINLINE constexpr V operator()(NU nu, V v) const noexcept
@@ -71,28 +80,4 @@ namespace kyosu
 //======================================================================================================================
 //! @}
 //======================================================================================================================
-}
-
-namespace kyosu::_
-{
-  template<typename NU, typename Z, eve::callable_options O>
-  KYOSU_FORCEINLINE constexpr auto cyl_bessel_i_(KYOSU_DELAY(), O const&, NU v, Z z) noexcept
-  {
-    if constexpr(concepts::complex<Z> )
-    {
-      return cb_ir(v, z);
-    }
-    else
-    {
-      return cayley_extend_rev(cyl_bessel_i, v, z);
-    }
-  }
-
-  template<typename NU, typename Z, std::size_t S, eve::callable_options O>
-  KYOSU_FORCEINLINE constexpr auto cyl_bessel_i_(KYOSU_DELAY(), O const&, NU v , Z z,
-                                                 std::span<Z, S> is) noexcept
-  {
-    return cb_ir(v, z, is);
-  }
-
 }

--- a/include/kyosu/functions/cyl_bessel_i.hpp
+++ b/include/kyosu/functions/cyl_bessel_i.hpp
@@ -17,7 +17,7 @@ namespace kyosu
     template<concepts::real NU, typename Z, std::size_t S>
     requires(concepts::real<Z> || concepts::cayley_dickson<Z>)
       KYOSU_FORCEINLINE constexpr auto  operator()(NU const& v, Z const & z, std::span<Z, S> is) const noexcept
-    {   return cb_ir(v, z, is); }
+    {   return _::cb_ir(v, z, is); }
 
     template<concepts::real NU, concepts::cayley_dickson Z>
     requires(eve::scalar_value<NU>)

--- a/include/kyosu/functions/cyl_bessel_i0.hpp
+++ b/include/kyosu/functions/cyl_bessel_i0.hpp
@@ -16,7 +16,16 @@ namespace kyosu
   {
     template<concepts::cayley_dickson Z>
     KYOSU_FORCEINLINE constexpr Z operator()(Z const& z) const noexcept
-    { return KYOSU_CALL(z); }
+    {
+      if constexpr(concepts::complex<Z> )
+      {
+        return _::cb_i0(z);
+      }
+      else
+      {
+        return _::cayley_extend(*this, z);
+      }
+    }
 
     template<concepts::real V>
     KYOSU_FORCEINLINE constexpr V operator()(V v) const noexcept
@@ -64,20 +73,4 @@ namespace kyosu
 //======================================================================================================================
 //! @}
 //======================================================================================================================
-}
-
-namespace kyosu::_
-{
-  template<typename Z, eve::callable_options O>
-  KYOSU_FORCEINLINE constexpr auto cyl_bessel_i0_(KYOSU_DELAY(), O const&, Z z) noexcept
-  {
-    if constexpr(concepts::complex<Z> )
-    {
-      return cb_i0(z);
-    }
-    else
-    {
-      return cayley_extend(cyl_bessel_i0, z);
-    }
-  }
 }

--- a/include/kyosu/functions/cyl_bessel_i1.hpp
+++ b/include/kyosu/functions/cyl_bessel_i1.hpp
@@ -16,7 +16,12 @@ namespace kyosu
   {
     template<concepts::cayley_dickson Z>
     KYOSU_FORCEINLINE constexpr Z operator()(Z const& z) const noexcept
-    { return KYOSU_CALL(z); }
+    {
+      if constexpr(concepts::complex<Z> )
+        return _::cb_i1(z);
+      else
+        return _::cayley_extend(*this, z);
+    }
 
     template<concepts::real V>
     KYOSU_FORCEINLINE constexpr V operator()(V v) const noexcept
@@ -64,20 +69,4 @@ namespace kyosu
 //======================================================================================================================
 //! @}
 //======================================================================================================================
-}
-
-namespace kyosu::_
-{
-  template<typename Z, eve::callable_options O>
-  KYOSU_FORCEINLINE constexpr auto cyl_bessel_i1_(KYOSU_DELAY(), O const&, Z z) noexcept
-  {
-    if constexpr(concepts::complex<Z> )
-    {
-      return cb_i1(z);
-    }
-    else
-    {
-      return cayley_extend(cyl_bessel_i1, z);
-    }
-  }
 }

--- a/include/kyosu/functions/cyl_bessel_ikn.hpp
+++ b/include/kyosu/functions/cyl_bessel_ikn.hpp
@@ -17,16 +17,28 @@ namespace kyosu
   {
     template<eve::integral_scalar_value Z0, typename Z1, std::size_t S>
     requires(concepts::real<Z1> || concepts::cayley_dickson<Z1>)
-      KYOSU_FORCEINLINE constexpr auto  operator()(Z0 const& z0, Z1 const & z1, std::span<Z1, S> js, std::span<Z1, S> ys) const noexcept
-    { return KYOSU_CALL(z0,z1,js,ys); }
+      KYOSU_FORCEINLINE constexpr auto  operator()(Z0 const& z0, Z1 const & z1, std::span<Z1, S> is, std::span<Z1, S> ks) const noexcept
+    {   return _::cb_ikn(n, z, is, ks); }
 
     template<eve::integral_scalar_value Z0, typename Z1>
     requires(concepts::real<Z1> || concepts::cayley_dickson<Z1>)
       KYOSU_FORCEINLINE constexpr auto  operator()(Z0 const& z0, Z1 const & z1) const noexcept
-    { return KYOSU_CALL(z0,z1); }
+    {
+      if constexpr(concepts::complex<Z> )
+      {
+        auto doit = [n, z](auto is, auto ks){
+          return _::cb_ikn(n, z, is, ks);
+        };
+        return with_alloca<Z>(eve::abs(n)+1, doit);
+      }
+      else
+      {
+        return cayley_extend_rev2(*this, n, z);
+      }
+    }
 
     KYOSU_CALLABLE_OBJECT(cyl_bessel_ikn_t, cyl_bessel_ikn_);
-};
+  };
 
 //======================================================================================================================
 //! @addtogroup functions
@@ -73,31 +85,4 @@ namespace kyosu
 //======================================================================================================================
 //! @}
 //======================================================================================================================
-}
-
-namespace kyosu::_
-{
-
-  template<typename N, typename Z, std::size_t S, eve::callable_options O>
-  KYOSU_FORCEINLINE constexpr auto cyl_bessel_ikn_(KYOSU_DELAY(), O const&, N n, Z z
-                                                 , std::span<Z, S> is, std::span<Z, S> ks) noexcept
-  {
-    return cb_ikn(n, z, is, ks);
-  }
-
-  template<typename N, typename Z, eve::callable_options O>
-  KYOSU_FORCEINLINE constexpr auto cyl_bessel_ikn_(KYOSU_DELAY(), O const&, N n, Z z) noexcept
-  {
-    if constexpr(concepts::complex<Z> )
-    {
-      auto doit = [n, z](auto is, auto ks){
-        return cb_ikn(n, z, is, ks);
-      };
-      return with_alloca<Z>(eve::abs(n)+1, doit);
-    }
-    else
-    {
-      return cayley_extend_rev2(cyl_bessel_ikn, n, z);
-    }
-  }
 }

--- a/include/kyosu/functions/cyl_bessel_in.hpp
+++ b/include/kyosu/functions/cyl_bessel_in.hpp
@@ -16,14 +16,25 @@ namespace kyosu
   template<typename Options>
   struct cyl_bessel_in_t : eve::strict_elementwise_callable<cyl_bessel_in_t, Options>
   {
-    template<eve::integral_scalar_value Z0, typename Z1, std::size_t S>
-    requires(concepts::real<Z1> || concepts::cayley_dickson<Z1>)
-      KYOSU_FORCEINLINE constexpr auto  operator()(Z0 const& z0, Z1 const & z1, std::span<Z1, S> js) const noexcept
-    { return KYOSU_CALL(z0,z1,js); }
+    template<eve::integral_scalar_value N, typename Z, std::size_t S>
+    requires(concepts::real<Z> || concepts::complex<Z>)
+      KYOSU_FORCEINLINE constexpr auto  operator()(N const& n, Z const & z, std::span<Z, S> js) const noexcept
+    {
+      auto doit = [n, z, &js](auto ys){
+        _::cb_ikn(n, z, js, ys);
+      };
+      with_alloca<Z>(eve::abs(n)+1, doit);
+      return js[n];
+    }
 
-    template<eve::integral_scalar_value Z0, concepts::cayley_dickson Z1>
-    KYOSU_FORCEINLINE constexpr auto operator()(Z0 const& z0, Z1 const & z1) const noexcept
-    { return KYOSU_CALL(z0,z1); }
+    template<eve::integral_scalar_value N, concepts::cayley_dickson Z>
+    KYOSU_FORCEINLINE constexpr auto operator()(N const& n, Z const & z) const noexcept
+    {
+      if constexpr(concepts::complex<Z> )
+        return _::cb_in(n, z);
+      else
+        return _::cayley_extend_rev(*this, n, z);
+    }
 
     template<eve::integral_scalar_value V0, concepts::real V1>
     KYOSU_FORCEINLINE constexpr auto operator()(V0 v0, V1 v1) const noexcept
@@ -78,31 +89,4 @@ namespace kyosu
 //======================================================================================================================
 //! @}
 //======================================================================================================================
-}
-
-namespace kyosu::_
-{
-  template<typename N, typename Z, eve::callable_options O>
-  KYOSU_FORCEINLINE constexpr auto cyl_bessel_in_(KYOSU_DELAY(), O const&, N n, Z z) noexcept
-  {
-     if constexpr(concepts::complex<Z> )
-    {
-      return cb_in(n, z);
-    }
-    else
-    {
-      return cayley_extend_rev(cyl_bessel_in, n, z);
-    }
-  }
-
-  template<typename N, typename Z, std::size_t S, eve::callable_options O>
-  KYOSU_FORCEINLINE constexpr auto cyl_bessel_in_(KYOSU_DELAY(), O const&
-                                                 , N n, Z z, std::span<Z, S> js) noexcept
-  {
-    auto doit = [n, z, &js](auto ys){
-      cb_ikn(n, z, js, ys);
-    };
-    with_alloca<Z>(eve::abs(n)+1, doit);
-    return js[n];
-  }
 }

--- a/include/kyosu/functions/cyl_bessel_j.hpp
+++ b/include/kyosu/functions/cyl_bessel_j.hpp
@@ -16,20 +16,25 @@ namespace kyosu
   {
     template<concepts::real NU, typename Z, std::size_t S>
     requires(concepts::real<Z> || concepts::cayley_dickson<Z>)
-      KYOSU_FORCEINLINE constexpr auto  operator()(NU const& nu, Z const & z, std::span<Z, S> js) const noexcept
-    { return KYOSU_CALL(nu,z,js); }
+      KYOSU_FORCEINLINE constexpr auto  operator()(NU const& v, Z const & z, std::span<Z, S> js) const noexcept
+    {  return _::cb_jr(v, z, js); }
 
     template<concepts::real NU, concepts::cayley_dickson Z>
     requires(eve::scalar_value<NU>)
-    KYOSU_FORCEINLINE constexpr Z operator()(NU nu, Z const& z) const noexcept
-    { return KYOSU_CALL(nu, z); }
+    KYOSU_FORCEINLINE constexpr Z operator()(NU v, Z const& z) const noexcept
+    {
+      if constexpr(concepts::complex<Z> )
+        return _::cb_jr(v, z);
+      else
+        return cayley_extend_rev(*this, v, z);
+    }
 
     template<concepts::real NU, concepts::real V>
     KYOSU_FORCEINLINE constexpr V operator()(NU nu, V v) const noexcept
-    { return  KYOSU_CALL(nu, complex(v)); }
+    { return  (*this)(nu, complex(v)); }
 
     KYOSU_CALLABLE_OBJECT(cyl_bessel_j_t, cyl_bessel_j_);
-};
+  };
 
 //======================================================================================================================
 //! @addtogroup functions
@@ -77,28 +82,4 @@ namespace kyosu
 //======================================================================================================================
 //! @}
 //======================================================================================================================
-}
-
-namespace kyosu::_
-{
-  template<typename NU, typename Z, eve::callable_options O>
-  KYOSU_FORCEINLINE constexpr auto cyl_bessel_j_(KYOSU_DELAY(), O const&, NU v, Z z) noexcept
-  {
-    if constexpr(concepts::complex<Z> )
-    {
-      return cb_jr(v, z);
-    }
-    else
-    {
-      return cayley_extend_rev(cyl_bessel_j, v, z);
-    }
-  }
-
-  template<typename NU, typename Z, std::size_t S, eve::callable_options O>
-  KYOSU_FORCEINLINE constexpr auto cyl_bessel_j_(KYOSU_DELAY(), O const&, NU v , Z z,
-                                                 std::span<Z, S> ks) noexcept
-  {
-   return cb_jr(v, z, ks);
-  }
-
 }

--- a/include/kyosu/functions/cyl_bessel_j0.hpp
+++ b/include/kyosu/functions/cyl_bessel_j0.hpp
@@ -17,7 +17,12 @@ namespace kyosu
   {
     template<concepts::cayley_dickson Z>
     KYOSU_FORCEINLINE constexpr Z operator()(Z const& z) const noexcept
-    { return KYOSU_CALL(z); }
+    {
+      if constexpr(concepts::complex<Z> )
+        return _::cb_j0(z);
+      else
+        return _::cayley_extend(*this, z);
+    }
 
     template<concepts::real V>
     KYOSU_FORCEINLINE constexpr V operator()(V v) const noexcept
@@ -66,20 +71,4 @@ namespace kyosu
 //======================================================================================================================
 //! @}
 //======================================================================================================================
-}
-
-namespace kyosu::_
-{
-  template<typename Z, eve::callable_options O>
-  KYOSU_FORCEINLINE constexpr auto cyl_bessel_j0_(KYOSU_DELAY(), O const&, Z z) noexcept
-  {
-    if constexpr(concepts::complex<Z> )
-    {
-      return cb_j0(z);
-    }
-    else
-    {
-      return cayley_extend(cyl_bessel_j0, z);
-    }
-  }
 }

--- a/include/kyosu/functions/cyl_bessel_j1.hpp
+++ b/include/kyosu/functions/cyl_bessel_j1.hpp
@@ -16,7 +16,16 @@ namespace kyosu
   {
     template<concepts::cayley_dickson Z>
     KYOSU_FORCEINLINE constexpr Z operator()(Z const& z) const noexcept
-    { return KYOSU_CALL(z); }
+    {
+      if constexpr(concepts::complex<Z> )
+      {
+        return _::cb_j1(z);
+      }
+      else
+      {
+        return _::cayley_extend(*this, z);
+      }
+    }
 
     template<concepts::real V>
     KYOSU_FORCEINLINE constexpr V operator()(V v) const noexcept
@@ -61,20 +70,4 @@ namespace kyosu
 //======================================================================================================================
 //! @}
 //======================================================================================================================
-}
-
-namespace kyosu::_
-{
-  template<typename Z, eve::callable_options O>
-  KYOSU_FORCEINLINE constexpr auto cyl_bessel_j1_(KYOSU_DELAY(), O const&, Z z) noexcept
-  {
-    if constexpr(concepts::complex<Z> )
-    {
-      return cb_j1(z);
-    }
-    else
-    {
-      return cayley_extend(cyl_bessel_j1, z);
-    }
-  }
 }

--- a/include/kyosu/functions/cyl_bessel_jn.hpp
+++ b/include/kyosu/functions/cyl_bessel_jn.hpp
@@ -18,13 +18,24 @@ namespace kyosu
   {
     template<eve::integral_scalar_value Z0, typename Z1, std::size_t S>
     requires(concepts::real<Z1> || concepts::cayley_dickson<Z1>)
-      KYOSU_FORCEINLINE constexpr auto  operator()(Z0 const& z0, Z1 const & z1, std::span<Z1, S> js) const noexcept
-    { return KYOSU_CALL(z0,z1,js); }
+      KYOSU_FORCEINLINE constexpr auto  operator()(Z0 const& n, Z1 const & z, std::span<Z1, S> js) const noexcept
+    {
+      auto doit = [n, z, &js](auto ys){
+        _::cb_jyn(n, z, js, ys);
+      };
+      _::with_alloca<Z1>(eve::abs(n)+1, doit);
+      return js[n];
+    }
 
     template<typename Z0, typename Z1>
     requires(eve::integral_scalar_value<Z0> && concepts::cayley_dickson<Z1>)
-    KYOSU_FORCEINLINE constexpr auto operator()(Z0 const& z0, Z1 const & z1) const noexcept
-    { return KYOSU_CALL(z0,z1); }
+    KYOSU_FORCEINLINE constexpr auto operator()(Z0 const& n, Z1 const & z) const noexcept
+    {
+      if constexpr(concepts::complex<Z1> )
+        return _::cb_jn(n, z);
+      else
+        return _::cayley_extend_rev(*this, n, z);
+    }
 
     template<eve::integral_scalar_value V0, concepts::real V1>
     KYOSU_FORCEINLINE constexpr auto operator()(V0 v0, V1 v1) const noexcept
@@ -81,31 +92,4 @@ namespace kyosu
 //======================================================================================================================
 //! @}
 //======================================================================================================================
-}
-
-namespace kyosu::_
-{
-  template<typename N, typename Z, eve::callable_options O>
-  KYOSU_FORCEINLINE constexpr auto cyl_bessel_jn_(KYOSU_DELAY(), O const&, N n, Z z) noexcept
-  {
-     if constexpr(concepts::complex<Z> )
-    {
-      return cb_jn(n, z);
-    }
-    else
-    {
-      return cayley_extend_rev(cyl_bessel_jn, n, z);
-    }
-  }
-
-  template<typename N, typename Z, std::size_t S, eve::callable_options O>
-  KYOSU_FORCEINLINE constexpr auto cyl_bessel_jn_(KYOSU_DELAY(), O const&
-                                                 , N n, Z z, std::span<Z, S> js) noexcept
-  {
-    auto doit = [n, z, &js](auto ys){
-      cb_jyn(n, z, js, ys);
-    };
-    with_alloca<Z>(eve::abs(n)+1, doit);
-    return js[n];
-  }
 }

--- a/include/kyosu/functions/cyl_bessel_jy.hpp
+++ b/include/kyosu/functions/cyl_bessel_jy.hpp
@@ -18,15 +18,27 @@ namespace kyosu
     template<concepts::real NU, typename Z, std::size_t S>
     requires(concepts::real<Z> || concepts::cayley_dickson<Z>)
       KYOSU_FORCEINLINE constexpr auto  operator()(NU const& v, Z const & z, std::span<Z, S> js, std::span<Z, S> ys) const noexcept
-    { return KYOSU_CALL(v,z,js,ys); }
+    { return _::cb_jyr(v, z, js, ys);; }
 
     template<concepts::real NU, typename Z>
     requires(concepts::real<Z> || concepts::cayley_dickson<Z>)
       KYOSU_FORCEINLINE constexpr auto  operator()(NU const& v, Z const & z) const noexcept
-    { return KYOSU_CALL(v,z); }
+    {
+      if constexpr(concepts::complex<Z> )
+      {
+        auto doit = [v, z](auto js, auto ys){
+          return _::cb_jyr(v, z, js, ys);
+        };
+        return with_alloca<Z>(eve::floor(eve::abs(v))+1, doit);
+      }
+      else
+      {
+        return _::cayley_extend_rev2(*this, v, z);
+      }
+    }
 
     KYOSU_CALLABLE_OBJECT(cyl_bessel_jy_t, cyl_bessel_jy_);
-};
+  };
 
 //======================================================================================================================
 //! @addtogroup functions
@@ -72,31 +84,4 @@ namespace kyosu
 //======================================================================================================================
 //! @}
 //======================================================================================================================
-}
-
-namespace kyosu::_
-{
-
-  template<typename N, typename Z, std::size_t S, eve::callable_options O>
-  KYOSU_FORCEINLINE constexpr auto cyl_bessel_jy_(KYOSU_DELAY(), O const&, N n, Z z
-                                                 , std::span<Z, S> js, std::span<Z, S> ys) noexcept
-  {
-    return cb_jyr(n, z, js, ys);
-  }
-
-  template<typename N, typename Z, eve::callable_options O>
-  KYOSU_FORCEINLINE constexpr auto cyl_bessel_jy_(KYOSU_DELAY(), O const&, N n, Z z) noexcept
-  {
-    if constexpr(concepts::complex<Z> )
-    {
-      auto doit = [n, z](auto js, auto ys){
-        return cb_jyr(n, z, js, ys);
-      };
-      return with_alloca<Z>(eve::abs(n)+1, doit);
-    }
-    else
-    {
-      return cayley_extend_rev2(cyl_bessel_jy, n, z);
-    }
-  }
 }

--- a/include/kyosu/functions/cyl_bessel_jyn.hpp
+++ b/include/kyosu/functions/cyl_bessel_jyn.hpp
@@ -17,13 +17,25 @@ namespace kyosu
   {
     template<eve::integral_scalar_value Z0, typename Z1, std::size_t S>
     requires(concepts::real<Z1> || concepts::cayley_dickson<Z1>)
-      KYOSU_FORCEINLINE constexpr auto  operator()(Z0 const& z0, Z1 const & z1, std::span<Z1, S> js, std::span<Z1, S> ys) const noexcept
-    { return KYOSU_CALL(z0,z1,js,ys); }
+      KYOSU_FORCEINLINE constexpr auto  operator()(Z0 const& n, Z1 const & z, std::span<Z1, S> js, std::span<Z1, S> ys) const noexcept
+    { return _::cb_jyn(n, z, js, ys); }
 
     template<eve::integral_scalar_value Z0, typename Z1>
     requires(concepts::real<Z1> || concepts::cayley_dickson<Z1>)
-      KYOSU_FORCEINLINE constexpr auto  operator()(Z0 const& z0, Z1 const & z1) const noexcept
-    { return KYOSU_CALL(z0,z1); }
+      KYOSU_FORCEINLINE constexpr auto  operator()(Z0 const& n, Z1 const & z) const noexcept
+    {
+      if constexpr(concepts::complex<Z1> )
+      {
+        auto doit = [n, z](auto js, auto ys){
+          return _::cb_jyn(n, z, js, ys);
+        };
+        return _::with_alloca<Z1>(eve::abs(n)+1, doit);
+      }
+      else
+      {
+        return _::cayley_extend_rev2(*this, n, z);
+      }
+    }
 
     KYOSU_CALLABLE_OBJECT(cyl_bessel_jyn_t, cyl_bessel_jyn_);
 };
@@ -72,31 +84,4 @@ namespace kyosu
 //======================================================================================================================
 //! @}
 //======================================================================================================================
-}
-
-namespace kyosu::_
-{
-
-  template<typename N, typename Z, std::size_t S, eve::callable_options O>
-  KYOSU_FORCEINLINE constexpr auto cyl_bessel_jyn_(KYOSU_DELAY(), O const&, N n, Z z
-                                                 , std::span<Z, S> js, std::span<Z, S> ys) noexcept
-  {
-    return cb_jyn(n, z, js, ys);
-  }
-
-  template<typename N, typename Z, eve::callable_options O>
-  KYOSU_FORCEINLINE constexpr auto cyl_bessel_jyn_(KYOSU_DELAY(), O const&, N n, Z z) noexcept
-  {
-    if constexpr(concepts::complex<Z> )
-    {
-      auto doit = [n, z](auto js, auto ys){
-        return cb_jyn(n, z, js, ys);
-      };
-      return with_alloca<Z>(eve::abs(n)+1, doit);
-    }
-    else
-    {
-      return cayley_extend_rev2(cyl_bessel_jyn, n, z);
-    }
-  }
 }

--- a/include/kyosu/functions/cyl_bessel_k.hpp
+++ b/include/kyosu/functions/cyl_bessel_k.hpp
@@ -17,17 +17,22 @@ namespace kyosu
   {
     template<concepts::real NU, typename Z, std::size_t S>
     requires(concepts::real<Z> || concepts::cayley_dickson<Z>)
-      KYOSU_FORCEINLINE constexpr auto  operator()(NU const& nu, Z const & z, std::span<Z, S> ks) const noexcept
-    { return KYOSU_CALL(nu,z,ks); }
+      KYOSU_FORCEINLINE constexpr auto  operator()(NU const& v, Z const & z, std::span<Z, S> ks) const noexcept
+    {   return _::cb_kr(v, z, ks); }
 
     template<concepts::real NU, concepts::cayley_dickson Z>
     requires(eve::scalar_value<NU>)
-    KYOSU_FORCEINLINE constexpr Z operator()(NU nu, Z const& z) const noexcept
-    { return KYOSU_CALL(nu, z); }
+      KYOSU_FORCEINLINE constexpr Z operator()(NU v, Z const& z) const noexcept
+    {
+      if constexpr(concepts::complex<Z> )
+        return _::cb_kr(v, z);
+      else
+        return _::cayley_extend_rev(*this, v, z);
+    }
 
     template<concepts::real NU, concepts::real V>
     KYOSU_FORCEINLINE constexpr V operator()(NU nu, V v) const noexcept
-    { return  KYOSU_CALL(nu, complex(v)); }
+    { return  (*this)(nu, complex(v)); }
 
     KYOSU_CALLABLE_OBJECT(cyl_bessel_k_t, cyl_bessel_k_);
 };
@@ -72,27 +77,4 @@ namespace kyosu
 //======================================================================================================================
 //! @}
 //======================================================================================================================
-}
-
-namespace kyosu::_
-{
- template<typename NU, typename Z, eve::callable_options O>
-  KYOSU_FORCEINLINE constexpr auto cyl_bessel_k_(KYOSU_DELAY(), O const&, NU v, Z z) noexcept
-  {
-    if constexpr(concepts::complex<Z> )
-    {
-      return cb_kr(v, z);
-    }
-    else
-    {
-      return cayley_extend_rev(cyl_bessel_i, v, z);
-    }
-  }
-
-  template<typename NU, typename Z, std::size_t S, eve::callable_options O>
-  KYOSU_FORCEINLINE constexpr auto cyl_bessel_k_(KYOSU_DELAY(), O const&, NU v , Z z,
-                                                 std::span<Z, S> ks) noexcept
-  {
-    return cb_kr(v, z, ks);
-  }
 }

--- a/include/kyosu/functions/cyl_bessel_k0.hpp
+++ b/include/kyosu/functions/cyl_bessel_k0.hpp
@@ -16,7 +16,12 @@ namespace kyosu
   {
     template<concepts::cayley_dickson Z>
     KYOSU_FORCEINLINE constexpr Z operator()(Z const& z) const noexcept
-    { return KYOSU_CALL(z); }
+    {
+      if constexpr(concepts::complex<Z> )
+        return _::cb_k0(z);
+      else
+        return _::cayley_extend(*this, z);
+    }
 
     template<concepts::real V>
     KYOSU_FORCEINLINE constexpr V operator()(V v) const noexcept
@@ -63,20 +68,4 @@ namespace kyosu
 //======================================================================================================================
 //! @}
 //======================================================================================================================
-}
-
-namespace kyosu::_
-{
-  template<typename Z, eve::callable_options O>
-  KYOSU_FORCEINLINE constexpr auto cyl_bessel_k0_(KYOSU_DELAY(), O const&, Z z) noexcept
-  {
-    if constexpr(concepts::complex<Z> )
-    {
-      return cb_k0(z);
-    }
-    else
-    {
-      return cayley_extend(cyl_bessel_k0, z);
-    }
-  }
 }

--- a/include/kyosu/functions/cyl_bessel_k1.hpp
+++ b/include/kyosu/functions/cyl_bessel_k1.hpp
@@ -16,7 +16,12 @@ namespace kyosu
   {
     template<concepts::cayley_dickson Z>
     KYOSU_FORCEINLINE constexpr Z operator()(Z const& z) const noexcept
-    { return KYOSU_CALL(z); }
+    {
+      if constexpr(concepts::complex<Z> )
+        return _::cb_k1(z);
+      else
+        return _::cayley_extend(*this, z);
+    }
 
     template<concepts::real V>
     KYOSU_FORCEINLINE constexpr V operator()(V v) const noexcept
@@ -62,20 +67,4 @@ namespace kyosu
 //======================================================================================================================
 //! @}
 //======================================================================================================================
-}
-
-namespace kyosu::_
-{
-  template<typename Z, eve::callable_options O>
-  KYOSU_FORCEINLINE constexpr auto cyl_bessel_k1_(KYOSU_DELAY(), O const&, Z z) noexcept
-  {
-    if constexpr(concepts::complex<Z> )
-    {
-      return cb_k1(z);
-    }
-    else
-    {
-      return cayley_extend(cyl_bessel_k1, z);
-    }
-  }
 }

--- a/include/kyosu/functions/cyl_bessel_kn.hpp
+++ b/include/kyosu/functions/cyl_bessel_kn.hpp
@@ -17,19 +17,34 @@ namespace kyosu
   {
     template<eve::integral_scalar_value Z0, typename Z1, std::size_t S>
     requires(concepts::real<Z1> || concepts::cayley_dickson<Z1>)
-      KYOSU_FORCEINLINE constexpr auto  operator()(Z0 const& z0, Z1 const & z1, std::span<Z1, S> ys) const noexcept
-    { return KYOSU_CALL(z0,z1,ys); }
+      KYOSU_FORCEINLINE constexpr auto  operator()(Z0 const& n, Z1 const & z, std::span<Z1, S> ks) const noexcept
+    {
+      auto doit = [n, z, &ks](auto is){
+        _::cb_ikn(n, z, is, ks);
+      };
+      _::with_alloca<Z1>(eve::abs(n)+1, doit);
+      return ks[n];
+    }
 
     template<eve::integral_scalar_value Z0, concepts::cayley_dickson Z1>
-    KYOSU_FORCEINLINE constexpr auto  operator()(Z0 const& z0, Z1 const & z1) const noexcept
-    { return KYOSU_CALL(z0,z1); }
+    KYOSU_FORCEINLINE constexpr auto  operator()(Z0 const& n, Z1 const & z) const noexcept
+    {
+      if constexpr(concepts::complex<Z1> )
+      {
+        return _::cb_kn(n, z);
+      }
+      else
+      {
+        return _::cayley_extend_rev(*this, n, z);
+      }
+    }
 
     template<eve::integral_scalar_value V0, concepts::real V1>
     KYOSU_FORCEINLINE constexpr auto operator()(V0 v0, V1 v1) const noexcept
     { return KYOSU_CALL(v0,v1); }
 
     KYOSU_CALLABLE_OBJECT(cyl_bessel_kn_t, cyl_bessel_kn_);
-};
+  };
 
 //======================================================================================================================
 //! @addtogroup functions
@@ -75,31 +90,4 @@ namespace kyosu
 //======================================================================================================================
 //! @}
 //======================================================================================================================
-}
-
-namespace kyosu::_
-{
-  template<typename N, typename Z, eve::callable_options O>
-  KYOSU_FORCEINLINE constexpr auto cyl_bessel_kn_(KYOSU_DELAY(), O const&, N n, Z z) noexcept
-  {
-    if constexpr(concepts::complex<Z> )
-    {
-      return cb_kn(n, z);
-    }
-    else
-    {
-      return cayley_extend_rev(cyl_bessel_kn, n, z);
-    }
-  }
-
-  template<typename N, typename Z, std::size_t S, eve::callable_options O>
-  KYOSU_FORCEINLINE constexpr auto cyl_bessel_kn_(KYOSU_DELAY(), O const&, N n, Z z
-                                                 , std::span<Z, S> ks) noexcept
-  {
-    auto doit = [n, z, &ks](auto is){
-      cb_ikn(n, z, is, ks);
-    };
-    with_alloca<Z>(eve::abs(n)+1, doit);
-    return ks[n];
-  }
 }

--- a/include/kyosu/functions/cyl_bessel_kn.hpp
+++ b/include/kyosu/functions/cyl_bessel_kn.hpp
@@ -41,7 +41,7 @@ namespace kyosu
 
     template<eve::integral_scalar_value V0, concepts::real V1>
     KYOSU_FORCEINLINE constexpr auto operator()(V0 v0, V1 v1) const noexcept
-    { return KYOSU_CALL(v0,v1); }
+    { return (*this)(v0,v1); }
 
     KYOSU_CALLABLE_OBJECT(cyl_bessel_kn_t, cyl_bessel_kn_);
   };

--- a/include/kyosu/functions/cyl_bessel_y.hpp
+++ b/include/kyosu/functions/cyl_bessel_y.hpp
@@ -47,7 +47,7 @@ namespace kyosu
 
     template<concepts::real NU, concepts::real V>
     KYOSU_FORCEINLINE constexpr V operator()(NU nu, V v) const noexcept
-    { return  KYOSU_CALL(nu, complex(v)); }
+    { return  (*this)(nu, complex(v)); }
 
     KYOSU_CALLABLE_OBJECT(cyl_bessel_y_t, cyl_bessel_y_);
 };

--- a/include/kyosu/functions/cyl_bessel_y0.hpp
+++ b/include/kyosu/functions/cyl_bessel_y0.hpp
@@ -16,7 +16,16 @@ namespace kyosu
   {
     template<concepts::cayley_dickson Z>
     KYOSU_FORCEINLINE constexpr Z operator()(Z const& z) const noexcept
-    { return KYOSU_CALL(z); }
+    {
+      if constexpr(concepts::complex<Z> )
+      {
+        return _::cb_y0(z);
+      }
+      else
+      {
+        return _::cayley_extend(*this, z);
+      }
+    }
 
     template<concepts::real V>
     KYOSU_FORCEINLINE constexpr V operator()(V v) const noexcept
@@ -63,20 +72,4 @@ namespace kyosu
 //======================================================================================================================
 //! @}
 //======================================================================================================================
-}
-
-namespace kyosu::_
-{
-  template<typename Z, eve::callable_options O>
-  KYOSU_FORCEINLINE constexpr auto cyl_bessel_y0_(KYOSU_DELAY(), O const&, Z z) noexcept
-  {
-    if constexpr(concepts::complex<Z> )
-    {
-      return cb_y0(z);
-    }
-    else
-    {
-      return cayley_extend(cyl_bessel_y0, z);
-    }
-  }
 }

--- a/include/kyosu/functions/cyl_bessel_y1.hpp
+++ b/include/kyosu/functions/cyl_bessel_y1.hpp
@@ -16,7 +16,16 @@ namespace kyosu
   {
     template<concepts::cayley_dickson Z>
     KYOSU_FORCEINLINE constexpr Z operator()(Z const& z) const noexcept
-    { return KYOSU_CALL(z); }
+    {
+      if constexpr(concepts::complex<Z> )
+      {
+        return _::cb_y1(z);
+      }
+      else
+      {
+        return _::cayley_extend(*this, z);
+      }
+    }
 
     template<concepts::real V>
     KYOSU_FORCEINLINE constexpr V operator()(V v) const noexcept
@@ -63,20 +72,4 @@ namespace kyosu
 //======================================================================================================================
 //! @}
 //======================================================================================================================
-}
-
-namespace kyosu::_
-{
-  template<typename Z, eve::callable_options O>
-  KYOSU_FORCEINLINE constexpr auto cyl_bessel_y1_(KYOSU_DELAY(), O const&, Z z) noexcept
-  {
-    if constexpr(concepts::complex<Z> )
-    {
-      return cb_y1(z);
-    }
-    else
-    {
-      return cayley_extend(cyl_bessel_y1, z);
-    }
-  }
 }

--- a/include/kyosu/functions/erfcx.hpp
+++ b/include/kyosu/functions/erfcx.hpp
@@ -31,7 +31,7 @@ namespace kyosu
       }
       else
       {
-        return kyosu::_::cayley_extend(*this, z);
+        return _::cayley_extend(*this, z);
       }
     }
 

--- a/include/kyosu/functions/erfi.hpp
+++ b/include/kyosu/functions/erfi.hpp
@@ -32,7 +32,7 @@ namespace kyosu
       }
       else
       {
-        return kyosu::_::cayley_extend(*this, z);
+        return ::_::cayley_extend(*this, z);
       }
     }
 

--- a/include/kyosu/functions/erfi.hpp
+++ b/include/kyosu/functions/erfi.hpp
@@ -32,7 +32,7 @@ namespace kyosu
       }
       else
       {
-        return ::_::cayley_extend(*this, z);
+        return _::cayley_extend(*this, z);
       }
     }
 

--- a/include/kyosu/functions/exp.hpp
+++ b/include/kyosu/functions/exp.hpp
@@ -33,7 +33,7 @@ namespace kyosu
       }
       else
       {
-        return kyosu::_::cayley_extend(*this, z);
+        return _::cayley_extend(*this, z);
       }
     }
 

--- a/include/kyosu/functions/expm1.hpp
+++ b/include/kyosu/functions/expm1.hpp
@@ -32,7 +32,7 @@ namespace kyosu
       }
       else
       {
-        return kyosu::_::cayley_extend(*this, z);
+        return _::cayley_extend(*this, z);
       }
     }
 

--- a/include/kyosu/functions/log.hpp
+++ b/include/kyosu/functions/log.hpp
@@ -35,7 +35,7 @@ namespace kyosu
       }
       else
       {
-        return kyosu::_::cayley_extend(*this, z);
+        return _::cayley_extend(*this, z);
       }
     }
 

--- a/include/kyosu/functions/log10.hpp
+++ b/include/kyosu/functions/log10.hpp
@@ -34,7 +34,7 @@ namespace kyosu
       }
       else
       {
-        return kyosu::_::cayley_extend(*this, z);
+        return _::cayley_extend(*this, z);
       }
     }
 

--- a/include/kyosu/functions/log1p.hpp
+++ b/include/kyosu/functions/log1p.hpp
@@ -31,7 +31,7 @@ namespace kyosu
          }
       else
       {
-        return kyosu::_::cayley_extend(*this, z);
+        return _::cayley_extend(*this, z);
       }
     }
 
@@ -84,4 +84,3 @@ namespace kyosu
 //! @}
 //======================================================================================================================
 }
-

--- a/include/kyosu/functions/log2.hpp
+++ b/include/kyosu/functions/log2.hpp
@@ -37,7 +37,7 @@ namespace kyosu
       }
       else
       {
-        return kyosu::_::cayley_extend(*this, z);
+        return _::cayley_extend(*this, z);
       }
     }
 

--- a/include/kyosu/functions/sin.hpp
+++ b/include/kyosu/functions/sin.hpp
@@ -24,7 +24,7 @@ namespace kyosu
       if constexpr(concepts::complex<Z> )
         return muli(kyosu::sinh(Z(mulmi(z))));
       else
-        return kyosu::_::cayley_extend(*this, z);
+        return _::cayley_extend(*this, z);
     }
 
     template<concepts::real V>

--- a/include/kyosu/functions/sinc.hpp
+++ b/include/kyosu/functions/sinc.hpp
@@ -26,7 +26,7 @@ namespace kyosu
       }
       else
       {
-        return kyosu::_::cayley_extend(*this, z);
+        return _::cayley_extend(*this, z);
       }
     }
 

--- a/include/kyosu/functions/sincos.hpp
+++ b/include/kyosu/functions/sincos.hpp
@@ -29,7 +29,7 @@ namespace kyosu
       }
       else
       {
-        return kyosu::_::cayley_extend2(*this, z);
+        return _::cayley_extend2(*this, z);
       }
     }
 

--- a/include/kyosu/functions/sinh.hpp
+++ b/include/kyosu/functions/sinh.hpp
@@ -44,7 +44,7 @@ namespace kyosu
       }
       else
       {
-        return kyosu::_::cayley_extend(*this, z);
+        return _::cayley_extend(*this, z);
       }
     }
 

--- a/include/kyosu/functions/sinhc.hpp
+++ b/include/kyosu/functions/sinhc.hpp
@@ -26,7 +26,7 @@ namespace kyosu
       }
       else
       {
-        return kyosu::_::cayley_extend(*this, z);
+        return _::cayley_extend(*this, z);
       }
     }
 

--- a/include/kyosu/functions/sinhcosh.hpp
+++ b/include/kyosu/functions/sinhcosh.hpp
@@ -51,7 +51,7 @@ namespace kyosu
       }
       else
       {
-        return kyosu::_::cayley_extend2(*this, z);
+        return _::cayley_extend2(*this, z);
       }
     }
 

--- a/include/kyosu/functions/sinpi.hpp
+++ b/include/kyosu/functions/sinpi.hpp
@@ -40,7 +40,7 @@ namespace kyosu
       }
       else
       {
-        return kyosu::_::cayley_extend(*this, z);
+        return _::cayley_extend(*this, z);
       }
     }
 

--- a/include/kyosu/functions/sinpicospi.hpp
+++ b/include/kyosu/functions/sinpicospi.hpp
@@ -55,7 +55,7 @@ namespace kyosu
       }
       else
       {
-        return kyosu::_::cayley_extend2(*this, z);
+        return _::cayley_extend2(*this, z);
       }
     }
 

--- a/include/kyosu/functions/sph_bessel_h1_0.hpp
+++ b/include/kyosu/functions/sph_bessel_h1_0.hpp
@@ -16,7 +16,7 @@ namespace kyosu
   {
     template<concepts::cayley_dickson Z>
     KYOSU_FORCEINLINE constexpr Z operator()(Z const& z) const noexcept
-    { return KYOSU_CALL(z); }
+    { return _::sb_h1_0(z); }
 
     template<concepts::real V>
     KYOSU_FORCEINLINE constexpr complex_t<V> operator()(V v) const noexcept
@@ -64,11 +64,3 @@ namespace kyosu
 //======================================================================================================================
 }
 
-namespace kyosu::_
-{
-  template<typename Z, eve::callable_options O>
-  KYOSU_FORCEINLINE constexpr auto sph_bessel_h1_0_(KYOSU_DELAY(), O const&, Z z) noexcept
-  {
-    return sb_h1_0(z);
-  }
-}

--- a/include/kyosu/functions/sph_bessel_h1_1.hpp
+++ b/include/kyosu/functions/sph_bessel_h1_1.hpp
@@ -16,7 +16,7 @@ namespace kyosu
   {
     template<concepts::cayley_dickson Z>
     KYOSU_FORCEINLINE constexpr Z operator()(Z const& z) const noexcept
-    { return KYOSU_CALL(z); }
+    { return _::sb_h1_1(z); }
 
     template<concepts::real V>
     KYOSU_FORCEINLINE constexpr complex_t<V> operator()(V v) const noexcept
@@ -62,13 +62,4 @@ namespace kyosu
 //======================================================================================================================
 //! @}
 //======================================================================================================================
-}
-
-namespace kyosu::_
-{
-  template<typename Z, eve::callable_options O>
-  KYOSU_FORCEINLINE constexpr auto sph_bessel_h1_1_(KYOSU_DELAY(), O const&, Z z) noexcept
-  {
-    return sb_h1_1(z);
-  }
 }

--- a/include/kyosu/functions/sph_bessel_h1n.hpp
+++ b/include/kyosu/functions/sph_bessel_h1n.hpp
@@ -16,7 +16,7 @@ namespace kyosu
   struct sph_bessel_h1n_t : eve::strict_elementwise_callable<sph_bessel_h1n_t, Options>
   {
     template<eve::integral_scalar_value N, typename Z>
-    requires(concepts::cayley_dickson<Z> || concepts::cayley_dickson<Z>)
+    requires(concepts::cayley_dickson<Z>)
     KYOSU_FORCEINLINE constexpr auto  operator()(N const& n, Z const & z) const noexcept
     {
       if constexpr(concepts::complex<Z>)
@@ -31,7 +31,7 @@ namespace kyosu
 
     template<eve::integral_scalar_value N, concepts::real V>
     KYOSU_FORCEINLINE constexpr complex_t<V> operator()(N n, V v) const noexcept
-    { return KYOSU_CALL(n,complex(v)); }
+    { return (*this)(n,complex(v)); }
 
     KYOSU_CALLABLE_OBJECT(sph_bessel_h1n_t, sph_bessel_h1n_);
 };

--- a/include/kyosu/functions/sph_bessel_h1n.hpp
+++ b/include/kyosu/functions/sph_bessel_h1n.hpp
@@ -18,7 +18,16 @@ namespace kyosu
     template<eve::integral_scalar_value N, typename Z>
     requires(concepts::cayley_dickson<Z> || concepts::cayley_dickson<Z>)
     KYOSU_FORCEINLINE constexpr auto  operator()(N const& n, Z const & z) const noexcept
-    { return KYOSU_CALL(n,z); }
+    {
+      if constexpr(concepts::complex<Z>)
+      {
+        return _::sb_h1n(n, z);
+      }
+      else
+      {
+        return _::cayley_extend_rev(*this, n, z);
+      }
+    }
 
     template<eve::integral_scalar_value N, concepts::real V>
     KYOSU_FORCEINLINE constexpr complex_t<V> operator()(N n, V v) const noexcept
@@ -64,20 +73,4 @@ namespace kyosu
 //======================================================================================================================
 //! @}
 //======================================================================================================================
-}
-
-namespace kyosu::_
-{
-  template<typename N, typename Z, eve::callable_options O>
-  KYOSU_FORCEINLINE constexpr auto sph_bessel_h1n_(KYOSU_DELAY(), O const&, N n, Z z) noexcept
-  {
-    if constexpr(concepts::complex<Z>)
-    {
-      return sb_h1n(n, z);
-    }
-    else
-    {
-      return cayley_extend_rev(sph_bessel_h1n, n, z);
-    }
-  }
 }

--- a/include/kyosu/functions/sph_bessel_h2_0.hpp
+++ b/include/kyosu/functions/sph_bessel_h2_0.hpp
@@ -16,7 +16,7 @@ namespace kyosu
   {
     template<concepts::cayley_dickson Z>
     KYOSU_FORCEINLINE constexpr Z operator()(Z const& z) const noexcept
-    { return KYOSU_CALL(z); }
+    { return _::sb_h2n(0, z); }
 
     template<concepts::real V>
     KYOSU_FORCEINLINE constexpr complex_t<V> operator()(V v) const noexcept
@@ -62,13 +62,4 @@ namespace kyosu
 //======================================================================================================================
 //! @}
 //======================================================================================================================
-}
-
-namespace kyosu::_
-{
-  template<typename Z, eve::callable_options O>
-  KYOSU_FORCEINLINE constexpr auto sph_bessel_h2_0_(KYOSU_DELAY(), O const&, Z z) noexcept
-  {
-    return sb_h2n(0, z);
-  }
 }

--- a/include/kyosu/functions/sph_bessel_h2_1.hpp
+++ b/include/kyosu/functions/sph_bessel_h2_1.hpp
@@ -16,7 +16,7 @@ namespace kyosu
   {
     template<concepts::cayley_dickson Z>
     KYOSU_FORCEINLINE constexpr Z operator()(Z const& z) const noexcept
-    { return KYOSU_CALL(z); }
+    { return _::sb_h2_1(z); }
 
     template<concepts::real V>
     KYOSU_FORCEINLINE constexpr complex_t<V> operator()(V v) const noexcept
@@ -62,13 +62,4 @@ namespace kyosu
 //======================================================================================================================
 //! @}
 //======================================================================================================================
-}
-
-namespace kyosu::_
-{
-  template<typename Z, eve::callable_options O>
-  KYOSU_FORCEINLINE constexpr auto sph_bessel_h2_1_(KYOSU_DELAY(), O const&, Z z) noexcept
-  {
-    return sb_h2_1(z);
-  }
 }

--- a/include/kyosu/functions/sph_bessel_h2n.hpp
+++ b/include/kyosu/functions/sph_bessel_h2n.hpp
@@ -15,14 +15,23 @@ namespace kyosu
   template<typename Options>
   struct sph_bessel_h2n_t : eve::strict_elementwise_callable<sph_bessel_h2n_t, Options>
   {
-    template<eve::integral_scalar_value N, typename Z1>
-    requires( concepts::cayley_dickson<Z1>)
-    KYOSU_FORCEINLINE constexpr auto  operator()(N n, Z1 const & z1) const noexcept
-    { return KYOSU_CALL(n,z1); }
+    template<eve::integral_scalar_value N, typename Z>
+    requires( concepts::cayley_dickson<Z>)
+    KYOSU_FORCEINLINE constexpr auto  operator()(N n, Z const & z) const noexcept
+    {
+      if constexpr(concepts::complex<Z>)
+      {
+        return _::sb_h2n(n, z);
+      }
+      else
+      {
+        return _::cayley_extend_rev(*this, n, z);
+      }
+    }
 
     template<eve::integral_scalar_value N, concepts::real V1>
     KYOSU_FORCEINLINE constexpr auto operator()(N n, V1 v1) const noexcept
-    { return KYOSU_CALL(n, v1); }
+    { return (*this)(n, v1); }
 
     KYOSU_CALLABLE_OBJECT(sph_bessel_h2n_t, sph_bessel_h2n_);
 };
@@ -66,18 +75,3 @@ namespace kyosu
 //======================================================================================================================
 }
 
-namespace kyosu::_
-{
-  template<typename N, typename Z, eve::callable_options O>
-  KYOSU_FORCEINLINE constexpr auto sph_bessel_h2n_(KYOSU_DELAY(), O const&, N n, Z z) noexcept
-  {
-    if constexpr(concepts::complex<Z>)
-    {
-      return sb_h2n(n, z);
-    }
-    else
-    {
-      return cayley_extend_rev(sph_bessel_h2n, n, z);
-    }
-  }
-}

--- a/include/kyosu/functions/sph_bessel_h2n.hpp
+++ b/include/kyosu/functions/sph_bessel_h2n.hpp
@@ -29,9 +29,9 @@ namespace kyosu
       }
     }
 
-    template<eve::integral_scalar_value N, concepts::real V1>
-    KYOSU_FORCEINLINE constexpr auto operator()(N n, V1 v1) const noexcept
-    { return (*this)(n, v1); }
+    template<eve::integral_scalar_value N, concepts::real V>
+    KYOSU_FORCEINLINE constexpr auto operator()(N n, V v) const noexcept
+    { return (*this)(n, complex(v)); }
 
     KYOSU_CALLABLE_OBJECT(sph_bessel_h2n_t, sph_bessel_h2n_);
 };
@@ -74,4 +74,3 @@ namespace kyosu
 //! @}
 //======================================================================================================================
 }
-

--- a/include/kyosu/functions/sph_bessel_i1_0.hpp
+++ b/include/kyosu/functions/sph_bessel_i1_0.hpp
@@ -16,7 +16,16 @@ namespace kyosu
   {
     template<concepts::cayley_dickson Z>
     KYOSU_FORCEINLINE constexpr Z operator()(Z const& z) const noexcept
-    { return KYOSU_CALL(z); }
+    {
+      if constexpr(concepts::complex<Z> )
+      {
+        return _::sb_i1_0(z);
+      }
+      else
+      {
+        return _::cayley_extend(*this, z);
+      }
+    }
 
     template<concepts::real V>
     KYOSU_FORCEINLINE constexpr complex_t<V> operator()(V v) const noexcept
@@ -62,20 +71,4 @@ namespace kyosu
 //======================================================================================================================
 //! @}
 //======================================================================================================================
-}
-
-namespace kyosu::_
-{
-  template<typename Z, eve::callable_options O>
-  KYOSU_FORCEINLINE constexpr auto sph_bessel_i1_0_(KYOSU_DELAY(), O const&, Z z) noexcept
-  {
-   if constexpr(concepts::complex<Z> )
-    {
-      return sb_i1_0(z);
-    }
-    else
-    {
-      return cayley_extend(sph_bessel_i1_0, z);
-    }
-  }
 }

--- a/include/kyosu/functions/sph_bessel_i1_1.hpp
+++ b/include/kyosu/functions/sph_bessel_i1_1.hpp
@@ -16,7 +16,12 @@ namespace kyosu
   {
     template<concepts::cayley_dickson Z>
     KYOSU_FORCEINLINE constexpr Z operator()(Z const& z) const noexcept
-    { return KYOSU_CALL(z); }
+    {
+      if constexpr(concepts::complex<Z> )
+        return _::sb_i1_1(z);
+      else
+        return _::cayley_extend(*this, z);
+    }
 
     template<concepts::real V>
     KYOSU_FORCEINLINE constexpr complex_t<V> operator()(V v) const noexcept
@@ -62,20 +67,4 @@ namespace kyosu
 //======================================================================================================================
 //! @}
 //======================================================================================================================
-}
-
-namespace kyosu::_
-{
-  template<typename Z, eve::callable_options O>
-  KYOSU_FORCEINLINE constexpr auto sph_bessel_i1_1_(KYOSU_DELAY(), O const&, Z z) noexcept
-  {
-    if constexpr(concepts::complex<Z> )
-    {
-      return sb_i1_1(z);
-    }
-    else
-    {
-      return cayley_extend(sph_bessel_i1_1, z);
-    }
-  }
 }

--- a/include/kyosu/functions/sph_bessel_i1n.hpp
+++ b/include/kyosu/functions/sph_bessel_i1n.hpp
@@ -39,7 +39,7 @@ namespace kyosu
 
     template<eve::integral_scalar_value V0, concepts::real V1>
     KYOSU_FORCEINLINE constexpr auto operator()(V0 v0, V1 v1) const noexcept
-    { return KYOSU_CALL(v0,complex(v1)); }
+    { return (*this)(v0,complex(v1)); }
 
     KYOSU_CALLABLE_OBJECT(sph_bessel_i1n_t, sph_bessel_i1n_);
 };

--- a/include/kyosu/functions/sph_bessel_i1n.hpp
+++ b/include/kyosu/functions/sph_bessel_i1n.hpp
@@ -16,15 +16,26 @@ namespace kyosu
   template<typename Options>
   struct sph_bessel_i1n_t : eve::strict_elementwise_callable<sph_bessel_i1n_t, Options>
   {
-    template<eve::integral_scalar_value Z0, typename Z1, std::size_t S>
-    requires(concepts::real<Z1> || concepts::cayley_dickson<Z1>)
-      KYOSU_FORCEINLINE constexpr auto  operator()(Z0 const& z0, Z1 const & z1, std::span<Z1, S> js) const noexcept
-    { return KYOSU_CALL(z0,z1,js); }
+    template<eve::integral_scalar_value N, typename Z, std::size_t S>
+    requires(concepts::real<Z> || concepts::complex<Z>)
+      KYOSU_FORCEINLINE constexpr auto  operator()(N const& n, Z const & z, std::span<Z, S> js) const noexcept
+    {
+      auto doit = [n, z, &js](auto ys){
+        sb_jyn(n, z, js, ys);
+      };
+      with_alloca<Z>(eve::abs(n)+1, doit);
+      return js[n];
+    }
 
-    template<typename Z0, typename Z1>
-    requires(eve::integral_scalar_value<Z0> && concepts::cayley_dickson<Z1>)
-    KYOSU_FORCEINLINE constexpr auto operator()(Z0 const& z0, Z1 const & z1) const noexcept
-    { return KYOSU_CALL(z0,z1); }
+    template<typename N, typename Z>
+    requires(eve::integral_scalar_value<N> && concepts::cayley_dickson<Z>)
+      KYOSU_FORCEINLINE constexpr auto operator()(N const& n, Z const & z) const noexcept
+    {
+      if constexpr(concepts::complex<Z> )
+        return _::sb_i1n(n, z);
+      else
+        return _::cayley_extend_rev(*this, n, z);
+    }
 
     template<eve::integral_scalar_value V0, concepts::real V1>
     KYOSU_FORCEINLINE constexpr auto operator()(V0 v0, V1 v1) const noexcept
@@ -81,31 +92,4 @@ namespace kyosu
 //======================================================================================================================
 //! @}
 //======================================================================================================================
-}
-
-namespace kyosu::_
-{
-  template<typename N, typename Z, eve::callable_options O>
-  KYOSU_FORCEINLINE constexpr auto sph_bessel_i1n_(KYOSU_DELAY(), O const&, N n, Z z) noexcept
-  {
-     if constexpr(concepts::complex<Z> )
-    {
-      return sb_i1n(n, z);
-    }
-    else
-    {
-      return cayley_extend_rev(sph_bessel_i1n, n, z);
-    }
-  }
-
-  template<typename N, typename Z, std::size_t S, eve::callable_options O>
-  KYOSU_FORCEINLINE constexpr auto sph_bessel_i1n_(KYOSU_DELAY(), O const&
-                                                 , N n, Z z, std::span<Z, S> is) noexcept
-  {
-    auto doit = [n, z, &is](auto ks){
-      sb_jyn(n, z, is, ks);
-    };
-    with_alloca<Z>(eve::abs(n)+1, doit);
-    return is[n];
-  }
 }

--- a/include/kyosu/functions/sph_bessel_i2_0.hpp
+++ b/include/kyosu/functions/sph_bessel_i2_0.hpp
@@ -16,7 +16,16 @@ namespace kyosu
   {
     template<concepts::cayley_dickson Z>
     KYOSU_FORCEINLINE constexpr Z operator()(Z const& z) const noexcept
-    { return KYOSU_CALL(z); }
+    {
+      if constexpr(concepts::complex<Z> )
+      {
+        return _::sb_i2_0(z);
+      }
+      else
+      {
+        return _::cayley_extend(*this, z);
+      }
+    }
 
     template<concepts::real V>
     KYOSU_FORCEINLINE constexpr complex_t<V> operator()(V v) const noexcept
@@ -62,20 +71,4 @@ namespace kyosu
 //======================================================================================================================
 //! @}
 //======================================================================================================================
-}
-
-namespace kyosu::_
-{
-  template<typename Z, eve::callable_options O>
-  KYOSU_FORCEINLINE constexpr auto sph_bessel_i2_0_(KYOSU_DELAY(), O const&, Z z) noexcept
-  {
-    if constexpr(concepts::complex<Z> )
-    {
-      return sb_i2_0(z);
-    }
-    else
-    {
-      return cayley_extend(sph_bessel_i2_0, z);
-    }
-  }
 }

--- a/include/kyosu/functions/sph_bessel_i2_1.hpp
+++ b/include/kyosu/functions/sph_bessel_i2_1.hpp
@@ -15,7 +15,12 @@ namespace kyosu
   {
     template<concepts::cayley_dickson Z>
     KYOSU_FORCEINLINE constexpr Z operator()(Z const& z) const noexcept
-    { return KYOSU_CALL(z); }
+    {
+      if constexpr(concepts::complex<Z> )
+        return _::sb_i2_1(z);
+      else
+        return _::cayley_extend(*this, z);
+    }
 
     template<concepts::real V>
     KYOSU_FORCEINLINE constexpr complex_t<V> operator()(V v) const noexcept
@@ -61,20 +66,4 @@ namespace kyosu
 //======================================================================================================================
 //! @}
 //======================================================================================================================
-}
-
-namespace kyosu::_
-{
-  template<typename Z, eve::callable_options O>
-  KYOSU_FORCEINLINE constexpr auto sph_bessel_i2_1_(KYOSU_DELAY(), O const&, Z z) noexcept
-  {
-    if constexpr(concepts::complex<Z> )
-    {
-      return sb_i2_1(z);
-    }
-    else
-    {
-      return cayley_extend(sph_bessel_i2_1, z);
-    }
-  }
 }

--- a/include/kyosu/functions/sph_bessel_i2n.hpp
+++ b/include/kyosu/functions/sph_bessel_i2n.hpp
@@ -43,7 +43,7 @@ namespace kyosu
 
     template<eve::integral_scalar_value V0, concepts::real V1>
     KYOSU_FORCEINLINE constexpr auto operator()(V0 v0, V1 v1) const noexcept
-    { return KYOSU_CALL(v0,v1); }
+    { return (*this)(v0,complex(v1)); }
 
     KYOSU_CALLABLE_OBJECT(sph_bessel_i2n_t, sph_bessel_i2n_);
 };

--- a/include/kyosu/functions/sph_bessel_i2n.hpp
+++ b/include/kyosu/functions/sph_bessel_i2n.hpp
@@ -16,15 +16,30 @@ namespace kyosu
   template<typename Options>
   struct sph_bessel_i2n_t : eve::strict_elementwise_callable<sph_bessel_i2n_t, Options>
   {
-    template<eve::integral_scalar_value Z0, typename Z1, std::size_t S>
-    requires(concepts::real<Z1> || concepts::cayley_dickson<Z1>)
-      KYOSU_FORCEINLINE constexpr auto  operator()(Z0 const& z0, Z1 const & z1, std::span<Z1, S> js) const noexcept
-    { return KYOSU_CALL(z0,z1,js); }
+    template<eve::integral_scalar_value N, typename Z, std::size_t S>
+    requires(concepts::real<Z> || concepts::complex<Z>)
+      KYOSU_FORCEINLINE constexpr auto  operator()(N const& n, Z const & z, std::span<Z, S> is) const noexcept
+    {
+      auto doit = [n, z, &is](auto ks){
+        sb_ikn(n, z, is, ks);
+      };
+      with_alloca<Z>(eve::abs(n)+1, doit);
+      return is[n];
+    }
 
-    template<typename Z0, typename Z1>
-    requires(eve::integral_scalar_value<Z0> && concepts::cayley_dickson<Z1>)
-    KYOSU_FORCEINLINE constexpr auto operator()(Z0 const& z0, Z1 const & z1) const noexcept
-    { return KYOSU_CALL(z0,z1); }
+    template<typename N, typename Z>
+    requires(eve::integral_scalar_value<N> && concepts::cayley_dickson<Z>)
+    KYOSU_FORCEINLINE constexpr auto operator()(N const& n, Z const & z) const noexcept
+    {
+      if constexpr(concepts::complex<Z> )
+      {
+        return _::sb_i2n(n, z);
+      }
+      else
+      {
+        return _::cayley_extend_rev(*this, n, z);
+      }
+    }
 
     template<eve::integral_scalar_value V0, concepts::real V1>
     KYOSU_FORCEINLINE constexpr auto operator()(V0 v0, V1 v1) const noexcept
@@ -80,31 +95,4 @@ namespace kyosu
 //======================================================================================================================
 //! @}
 //======================================================================================================================
-}
-
-namespace kyosu::_
-{
-  template<typename N, typename Z, eve::callable_options O>
-  KYOSU_FORCEINLINE constexpr auto sph_bessel_i2n_(KYOSU_DELAY(), O const&, N n, Z z) noexcept
-  {
-     if constexpr(concepts::complex<Z> )
-    {
-      return sb_i2n(n, z);
-    }
-    else
-    {
-      return cayley_extend_rev(sph_bessel_i2n, n, z);
-    }
-  }
-
-  template<typename N, typename Z, std::size_t S, eve::callable_options O>
-  KYOSU_FORCEINLINE constexpr auto sph_bessel_i2n_(KYOSU_DELAY(), O const&
-                                                 , N n, Z z, std::span<Z, S> is) noexcept
-  {
-    auto doit = [n, z, &is](auto ks){
-      sb_ikn(n, z, is, ks);
-    };
-    with_alloca<Z>(eve::abs(n)+1, doit);
-    return is[n];
-  }
 }

--- a/include/kyosu/functions/sph_bessel_j0.hpp
+++ b/include/kyosu/functions/sph_bessel_j0.hpp
@@ -16,7 +16,7 @@ namespace kyosu
   {
     template<concepts::cayley_dickson Z>
     KYOSU_FORCEINLINE constexpr Z operator()(Z const& z) const noexcept
-    { return KYOSU_CALL(z); }
+    { return _::sb_j0(z); }
 
     template<concepts::real V>
     KYOSU_FORCEINLINE constexpr V operator()(V v) const noexcept
@@ -62,13 +62,4 @@ namespace kyosu
 //======================================================================================================================
 //! @}
 //======================================================================================================================
-}
-
-namespace kyosu::_
-{
-  template<typename Z, eve::callable_options O>
-  KYOSU_FORCEINLINE constexpr auto sph_bessel_j0_(KYOSU_DELAY(), O const&, Z z) noexcept
-  {
-     return sb_j0(z);
-  }
 }

--- a/include/kyosu/functions/sph_bessel_j1.hpp
+++ b/include/kyosu/functions/sph_bessel_j1.hpp
@@ -16,7 +16,12 @@ namespace kyosu
   {
     template<concepts::cayley_dickson Z>
     KYOSU_FORCEINLINE constexpr Z operator()(Z const& z) const noexcept
-    { return KYOSU_CALL(z); }
+    {
+      if constexpr(concepts::complex<Z> )
+        return _::sb_j1(z);
+      else
+        return _::cayley_extend(*this, z);
+    }
 
     template<concepts::real V>
     KYOSU_FORCEINLINE constexpr V operator()(V v) const noexcept
@@ -63,20 +68,4 @@ namespace kyosu
 //======================================================================================================================
 //! @}
 //======================================================================================================================
-}
-
-namespace kyosu::_
-{
-  template<typename Z, eve::callable_options O>
-  KYOSU_FORCEINLINE constexpr auto sph_bessel_j1_(KYOSU_DELAY(), O const&, Z z) noexcept
-  {
-    if constexpr(concepts::complex<Z> )
-    {
-      return sb_j1(z);
-    }
-    else
-    {
-      return cayley_extend(sph_bessel_j1, z);
-    }
-  }
 }

--- a/include/kyosu/functions/sph_bessel_jn.hpp
+++ b/include/kyosu/functions/sph_bessel_jn.hpp
@@ -16,15 +16,20 @@ namespace kyosu
   template<typename Options>
   struct sph_bessel_jn_t : eve::strict_elementwise_callable<sph_bessel_jn_t, Options>
   {
-    template<eve::integral_scalar_value Z0, typename Z1, std::size_t S>
-    requires(concepts::real<Z1> || concepts::cayley_dickson<Z1>)
-      KYOSU_FORCEINLINE constexpr auto  operator()(Z0 const& z0, Z1 const & z1, std::span<Z1, S> js) const noexcept
-    { return KYOSU_CALL(z0,z1,js); }
+    template<eve::integral_scalar_value N, typename Z, std::size_t S>
+    requires(concepts::real<Z> || concepts::cayley_dickson<Z>)
+      KYOSU_FORCEINLINE constexpr auto  operator()(N const& n, Z const & z, std::span<Z, S> js) const noexcept
+    { return sb_jn(n, z, js); }
 
-    template<eve::integral_scalar_value Z0, concepts::cayley_dickson Z1>
+    template<eve::integral_scalar_value N, concepts::cayley_dickson Z>
     //    requires(eve::integral_scalar_value<Z0> && concepts::cayley_dickson<Z1>)
-    KYOSU_FORCEINLINE constexpr auto operator()(Z0 const& z0, Z1 const & z1) const noexcept
-    { return KYOSU_CALL(z0,z1); }
+    KYOSU_FORCEINLINE constexpr auto operator()(N const& n, Z const & z) const noexcept
+    {
+      if constexpr(concepts::complex<Z> )
+        return _::sb_jn(n, z);
+      else
+        return _::cayley_extend_rev(*this, n, z);
+    }
 
     template<concepts::real V0, concepts::real V1>
     KYOSU_FORCEINLINE constexpr auto operator()(V0 v0, V1 v1) const noexcept
@@ -78,27 +83,4 @@ namespace kyosu
 //======================================================================================================================
 //! @}
 //======================================================================================================================
-}
-
-namespace kyosu::_
-{
-  template<typename N, typename Z, eve::callable_options O>
-  KYOSU_FORCEINLINE constexpr auto sph_bessel_jn_(KYOSU_DELAY(), O const&, N n, Z z) noexcept
-  {
-     if constexpr(concepts::complex<Z> )
-    {
-      return sb_jn(n, z);
-    }
-    else
-    {
-      return cayley_extend_rev(sph_bessel_jn, n, z);
-    }
-  }
-
-  template<typename N, typename Z, std::size_t S, eve::callable_options O>
-  KYOSU_FORCEINLINE constexpr auto sph_bessel_jn_(KYOSU_DELAY(), O const&
-                                                 , N n, Z z, std::span<Z, S> js) noexcept
-  {
-    return sb_jn(n, z, js);
-  }
 }

--- a/include/kyosu/functions/sph_bessel_k0.hpp
+++ b/include/kyosu/functions/sph_bessel_k0.hpp
@@ -16,7 +16,12 @@ namespace kyosu
   {
     template<concepts::cayley_dickson Z>
     KYOSU_FORCEINLINE constexpr Z operator()(Z const& z) const noexcept
-    { return KYOSU_CALL(z); }
+    {
+      if constexpr(concepts::complex<Z> )
+        return _::sb_k0(z);
+      else
+        return _::cayley_extend(*this, z);
+    }
 
     template<concepts::real V>
     KYOSU_FORCEINLINE constexpr complex_t<V> operator()(V v) const noexcept
@@ -62,20 +67,4 @@ namespace kyosu
 //======================================================================================================================
 //! @}
 //======================================================================================================================
-}
-
-namespace kyosu::_
-{
-  template<typename Z, eve::callable_options O>
-  KYOSU_FORCEINLINE constexpr auto sph_bessel_k0_(KYOSU_DELAY(), O const&, Z z) noexcept
-  {
-    if constexpr(concepts::complex<Z> )
-    {
-     return sb_k0(z);
-    }
-    else
-    {
-      return cayley_extend(sph_bessel_k0, z);
-    }
-  }
 }

--- a/include/kyosu/functions/sph_bessel_k1.hpp
+++ b/include/kyosu/functions/sph_bessel_k1.hpp
@@ -16,7 +16,16 @@ namespace kyosu
   {
     template<concepts::cayley_dickson Z>
     KYOSU_FORCEINLINE constexpr Z operator()(Z const& z) const noexcept
-    { return KYOSU_CALL(z); }
+    {
+      if constexpr(concepts::complex<Z> )
+      {
+        return _::sb_k1(z);
+      }
+      else
+      {
+        return _::cayley_extend(*this, z);
+      }
+    }
 
     template<concepts::real V>
     KYOSU_FORCEINLINE constexpr complex_t<V> operator()(V v) const noexcept
@@ -62,20 +71,4 @@ namespace kyosu
 //======================================================================================================================
 //! @}
 //======================================================================================================================
-}
-
-namespace kyosu::_
-{
-  template<typename Z, eve::callable_options O>
-  KYOSU_FORCEINLINE constexpr auto sph_bessel_k1_(KYOSU_DELAY(), O const&, Z z) noexcept
-  {
-    if constexpr(concepts::complex<Z> )
-    {
-      return sb_k1(z);
-    }
-    else
-    {
-      return cayley_extend(sph_bessel_k1, z);
-    }
-  }
 }

--- a/include/kyosu/functions/sph_bessel_kn.hpp
+++ b/include/kyosu/functions/sph_bessel_kn.hpp
@@ -43,7 +43,7 @@ namespace kyosu
 
     template<eve::integral_scalar_value V0, concepts::real V1>
     KYOSU_FORCEINLINE constexpr auto operator()(V0 v0, V1 v1) const noexcept
-    { return KYOSU_CALL(v0,complex(v1)); }
+    { return (*this)(v0,complex(v1)); }
 
     KYOSU_CALLABLE_OBJECT(sph_bessel_kn_t, sph_bessel_kn_);
 };

--- a/include/kyosu/functions/sph_bessel_kn.hpp
+++ b/include/kyosu/functions/sph_bessel_kn.hpp
@@ -16,15 +16,30 @@ namespace kyosu
   template<typename Options>
   struct sph_bessel_kn_t : eve::strict_elementwise_callable<sph_bessel_kn_t, Options>
   {
-    template<eve::integral_scalar_value Z0, typename Z1, std::size_t S>
-    requires(concepts::real<Z1> || concepts::cayley_dickson<Z1>)
-      KYOSU_FORCEINLINE constexpr auto  operator()(Z0 const& z0, Z1 const & z1, std::span<Z1, S> js) const noexcept
-    { return KYOSU_CALL(z0,z1,js); }
+    template<eve::integral_scalar_value N, typename Z, std::size_t S>
+    requires(concepts::real<Z> || concepts::cayley_dickson<Z>)
+      KYOSU_FORCEINLINE constexpr auto  operator()(N const& n, Z const & z, std::span<Z, S> js) const noexcept
+    {
+      auto doit = [n, z, &js](auto ys){
+        _::sb_jyn(n, z, js, ys);
+      };
+      with_alloca<Z>(eve::abs(n)+1, doit);
+      return js[n];
+    }
 
-    template<typename Z0, typename Z1>
-    requires(eve::integral_scalar_value<Z0> && concepts::cayley_dickson<Z1>)
-    KYOSU_FORCEINLINE constexpr auto operator()(Z0 const& z0, Z1 const & z1) const noexcept
-    { return KYOSU_CALL(z0,z1); }
+    template<typename N, typename Z>
+    requires(eve::integral_scalar_value<N> && concepts::cayley_dickson<Z>)
+    KYOSU_FORCEINLINE constexpr auto operator()(N const& n, Z const & z) const noexcept
+    {
+      if constexpr(concepts::complex<Z> )
+      {
+        return _::sb_kn(n, z);
+      }
+      else
+      {
+        return _::cayley_extend_rev(*this, n, z);
+      }
+    }
 
     template<eve::integral_scalar_value V0, concepts::real V1>
     KYOSU_FORCEINLINE constexpr auto operator()(V0 v0, V1 v1) const noexcept
@@ -76,31 +91,4 @@ namespace kyosu
 //======================================================================================================================
 //! @}
 //======================================================================================================================
-}
-
-namespace kyosu::_
-{
-  template<typename N, typename Z, eve::callable_options O>
-  KYOSU_FORCEINLINE constexpr auto sph_bessel_kn_(KYOSU_DELAY(), O const&, N n, Z z) noexcept
-  {
-     if constexpr(concepts::complex<Z> )
-    {
-      return sb_kn(n, z);
-    }
-    else
-    {
-      return cayley_extend_rev(sph_bessel_kn, n, z);
-    }
-  }
-
-  template<typename N, typename Z, std::size_t S, eve::callable_options O>
-  KYOSU_FORCEINLINE constexpr auto sph_bessel_kn_(KYOSU_DELAY(), O const&
-                                                 , N n, Z z, std::span<Z, S> js) noexcept
-  {
-    auto doit = [n, z, &js](auto ys){
-      sb_jyn(n, z, js, ys);
-    };
-    with_alloca<Z>(eve::abs(n)+1, doit);
-    return js[n];
-  }
 }

--- a/include/kyosu/functions/sph_bessel_y0.hpp
+++ b/include/kyosu/functions/sph_bessel_y0.hpp
@@ -16,7 +16,16 @@ namespace kyosu
   {
     template<concepts::cayley_dickson Z>
     KYOSU_FORCEINLINE constexpr Z operator()(Z const& z) const noexcept
-    { return KYOSU_CALL(z); }
+    {
+      if constexpr(concepts::complex<Z> )
+      {
+        return _::sb_y0(z);
+      }
+      else
+      {
+        return _::cayley_extend(*this, z);
+      }
+    }
 
     template<concepts::real V>
     KYOSU_FORCEINLINE constexpr V operator()(V v) const noexcept
@@ -62,20 +71,4 @@ namespace kyosu
 //======================================================================================================================
 //! @}
 //======================================================================================================================
-}
-
-namespace kyosu::_
-{
-  template<typename Z, eve::callable_options O>
-  KYOSU_FORCEINLINE constexpr auto sph_bessel_y0_(KYOSU_DELAY(), O const&, Z z) noexcept
-  {
-    if constexpr(concepts::complex<Z> )
-    {
-     return sb_y0(z);
-    }
-    else
-    {
-      return cayley_extend(sph_bessel_y0, z);
-    }
-  }
 }

--- a/include/kyosu/functions/sph_bessel_y1.hpp
+++ b/include/kyosu/functions/sph_bessel_y1.hpp
@@ -16,7 +16,12 @@ namespace kyosu
   {
     template<concepts::cayley_dickson Z>
     KYOSU_FORCEINLINE constexpr Z operator()(Z const& z) const noexcept
-    { return KYOSU_CALL(z); }
+    {
+      if constexpr(concepts::complex<Z> )
+        return _::sb_y1(z);
+      else
+        return _::cayley_extend(*this, z);
+    }
 
     template<concepts::real V>
     KYOSU_FORCEINLINE constexpr V operator()(V v) const noexcept
@@ -63,20 +68,4 @@ namespace kyosu
 //======================================================================================================================
 //! @}
 //======================================================================================================================
-}
-
-namespace kyosu::_
-{
-  template<typename Z, eve::callable_options O>
-  KYOSU_FORCEINLINE constexpr auto sph_bessel_y1_(KYOSU_DELAY(), O const&, Z z) noexcept
-  {
-    if constexpr(concepts::complex<Z> )
-    {
-      return sb_y1(z);
-    }
-    else
-    {
-      return cayley_extend(sph_bessel_y1, z);
-    }
-  }
 }

--- a/include/kyosu/functions/sph_bessel_yn.hpp
+++ b/include/kyosu/functions/sph_bessel_yn.hpp
@@ -15,19 +15,26 @@ namespace kyosu
   template<typename Options>
   struct sph_bessel_yn_t : eve::strict_elementwise_callable<sph_bessel_yn_t, Options>
   {
-    template<eve::integral_scalar_value Z0, typename Z1, std::size_t S>
-    requires(concepts::real<Z1> || concepts::cayley_dickson<Z1>)
-      KYOSU_FORCEINLINE constexpr auto  operator()(Z0 const& z0, Z1 const & z1, std::span<Z1, S> ys) const noexcept
-    { return KYOSU_CALL(z0,z1,ys); }
+    template<eve::integral_scalar_value N, typename Z, std::size_t S>
+    requires(eve::integral_scalar_value<N> || concepts::cayley_dickson<Z>)
+      KYOSU_FORCEINLINE constexpr auto  operator()(N const& n, Z const & z, std::span<Z, S> ys) const noexcept
+    {
+      return sb_yn(n, z, ys);
+    }
 
-    template<eve::integral_scalar_value Z0, typename Z1>
-    requires( concepts::cayley_dickson<Z1>)
-    KYOSU_FORCEINLINE constexpr auto  operator()(Z0 const& z0, Z1 const & z1) const noexcept
-    { return KYOSU_CALL(z0,z1); }
+    template<eve::integral_scalar_value N, typename Z>
+    requires( concepts::cayley_dickson<Z>)
+    KYOSU_FORCEINLINE constexpr auto  operator()(N const& n, Z const & z) const noexcept
+    {
+      if constexpr(concepts::complex<Z> )
+        return _::sb_yn(n, z);
+      else
+        return _::cayley_extend_rev(*this, n, z);
+    }
 
     template<eve::integral_scalar_value V0, concepts::real V1>
     KYOSU_FORCEINLINE constexpr auto operator()(V0 v0, V1 v1) const noexcept
-    { return KYOSU_CALL(v0,v1); }
+    { return eve::sph_bessel_yn(v0,v1); }
 
     KYOSU_CALLABLE_OBJECT(sph_bessel_yn_t, sph_bessel_yn_);
 };
@@ -78,27 +85,4 @@ namespace kyosu
 //======================================================================================================================
 //! @}
 //======================================================================================================================
-}
-
-namespace kyosu::_
-{
-  template<typename N, typename Z, eve::callable_options O>
-  KYOSU_FORCEINLINE constexpr auto sph_bessel_yn_(KYOSU_DELAY(), O const&, N n, Z z) noexcept
-  {
-    if constexpr(concepts::complex<Z> )
-    {
-      return sb_yn(n, z);
-    }
-    else
-    {
-      return cayley_extend_rev(sph_bessel_yn, n, z);
-    }
-  }
-
-  template<typename N, typename Z, std::size_t S, eve::callable_options O>
-  KYOSU_FORCEINLINE constexpr auto sph_bessel_yn_(KYOSU_DELAY(), O const&, N n, Z z
-                                                 , std::span<Z, S> ys) noexcept
-  {
-    return sb_yn(n, z, ys);
-  }
 }

--- a/include/kyosu/functions/tan.hpp
+++ b/include/kyosu/functions/tan.hpp
@@ -23,7 +23,7 @@ namespace kyosu
       if constexpr(concepts::complex<Z> )
         return mulmi(kyosu::tanh(muli(z)));
       else
-        return kyosu::_::cayley_extend(*this, z);
+        return _::cayley_extend(*this, z);
     }
 
     template<concepts::real V>

--- a/include/kyosu/functions/tanh.hpp
+++ b/include/kyosu/functions/tanh.hpp
@@ -30,7 +30,7 @@ namespace kyosu
       }
       else
       {
-        return kyosu::_::cayley_extend(*this, z);
+        return _::cayley_extend(*this, z);
       }
     }
 

--- a/include/kyosu/functions/tanpi.hpp
+++ b/include/kyosu/functions/tanpi.hpp
@@ -34,7 +34,7 @@ namespace kyosu
       }
       else
       {
-        return kyosu::_::cayley_extend(*this, z);
+        return _::cayley_extend(*this, z);
       }
     }
 

--- a/include/kyosu/functions/zeta.hpp
+++ b/include/kyosu/functions/zeta.hpp
@@ -29,7 +29,7 @@ namespace kyosu
       }
       else
       {
-        return kyosu::_::cayley_extend(*this, z);
+        return _::cayley_extend(*this, z);
       }
     }
 

--- a/test/unit/function/signnz.cpp
+++ b/test/unit/function/signnz.cpp
@@ -1,0 +1,33 @@
+//======================================================================================================================
+/*
+  Kyosu - Complex Without Complexes
+  Copyright : KYOSU Contributors & Maintainers
+  SPDX-License-Identifier: BSL-1.0
+*/
+//======================================================================================================================
+#include <kyosu/kyosu.hpp>
+#include <test.hpp>
+
+TTS_CASE_WITH ( "Check kyosu::signnz over real"
+              , kyosu::real_types
+              , tts::generate(tts::randoms(-10,10))
+              )
+(auto data)
+{
+  TTS_ULP_EQUAL(kyosu::signnz(data), eve::signnz(data), 0.5);
+};
+
+
+TTS_CASE_WITH ( "Check kyosu::signnz over quaternion"
+              , kyosu::simd_real_types
+              , tts::generate ( tts::randoms(-10,10), tts::randoms(-10,10)
+                              , tts::randoms(-10,10), tts::randoms(-10,10)
+                              )
+              )
+<typename T>(T r, T i, T j, T k)
+{
+  using ke_t = kyosu::quaternion_t<T>;
+  auto q = ke_t(r,i,j,k);
+  TTS_RELATIVE_EQUAL(kyosu::signnz(q), q/kyosu::abs(q), tts::prec<T>());
+  TTS_RELATIVE_EQUAL(kyosu::signnz(kyosu::quaternion(T(0.0))), kyosu::quaternion(T(1.0)),  tts::prec<T>());
+};


### PR DESCRIPTION
continuing to suppress most of KYOSU_CALL
bessel are still to improve versus alloca scheme and CD extension un case of using spans
KYOSU_CALL only remains to 'big' implementations