### PR TITLE
Give the benchmarks their own target and their own pass

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,71 @@
+##======================================================================================================================
+## Kyosu - Complex Without Complexes
+## Copyright : KYOSU Contributors & Maintainers
+## SPDX-License-Identifier: BSL-1.0
+##======================================================================================================================
+## Benchmarks gate nothing, so they run once a change has landed rather than on every pull request,
+## where they were a quarter of the build for no signal. They also need their own presets: the ones
+## used for testing define EVE_NO_FORCEINLINE, which a Release build does not undo.
+##======================================================================================================================
+name: KYOSU Benchmarks
+on:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: kyosu-benchmarks-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  benchmarks:
+    name: ${{ matrix.compiler.name }}
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/jfalcou/compilers:v10
+      options: -u root
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler:
+          - { name: "gcc"  , preset: "gcc-bench"   }
+          - { name: "clang", preset: "clang-bench" }
+
+    steps:
+      - name: Fetch current branch
+        uses: actions/checkout@v6
+
+      - name: Configure CMake and Build
+        uses: ./.github/actions/config
+        with:
+          config: Release
+          preset: ${{ matrix.compiler.preset }}
+          targets: kyosu-bench
+
+      - name: Run Benchmarks
+        shell: bash
+        env:
+          PRESET: ${{ matrix.compiler.preset }}
+        run: |
+          out="benchmarks-${{ matrix.compiler.name }}.md"
+          {
+            echo "# Benchmarks, ${{ matrix.compiler.name }}"
+            echo
+            echo "Run on a shared runner with hardware counters unavailable, so cycle and"
+            echo "instruction columns read zero and the rest is indicative, not a measurement."
+            echo
+          } > "$out"
+
+          find "build/$PRESET/benchmarks/Release" -name 'benchmarks.*.exe' -type f -print0 \
+          | sort -z | while IFS= read -r -d '' exe; do
+              echo "## $(basename "$exe" .exe)" >> "$out"
+              "$exe" >> "$out" 2>&1 || echo "> this one failed to run" >> "$out"
+            done
+
+          cat "$out" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload the aggregated output
+        uses: actions/upload-artifact@v7
+        with:
+          name: benchmarks-${{ matrix.compiler.name }}
+          path: benchmarks-${{ matrix.compiler.name }}.md

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           config: Debug
           preset: ${{ matrix.compiler.preset }}
-          targets: doc.exe unit.exe benchmarks.exe
+          targets: doc.exe unit.exe
 
       - name: Run Doc Tests
         uses: ./.github/actions/test

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           config: Debug
           preset: ${{ matrix.compiler.preset }}
-          targets: doc.exe unit.exe benchmarks.exe
+          targets: doc.exe unit.exe
 
       - name: Run Doc Tests
         uses: ./.github/actions/test

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -31,6 +31,9 @@
     { "name": "clang"        , "inherits": ["unix-base"], "cacheVariables": { "CMAKE_CXX_COMPILER": "clang++-20", "CMAKE_CXX_FLAGS": "-O0 -DEVE_NO_FORCEINLINE"        } },
     { "name": "clang-avx2"   , "inherits": ["unix-base"], "cacheVariables": { "CMAKE_CXX_COMPILER": "clang++-20", "CMAKE_CXX_FLAGS": "-O0 -DEVE_NO_FORCEINLINE -mavx2" } },
 
+    { "name": "gcc-bench"    , "inherits": ["unix-base"], "cacheVariables": { "CMAKE_CXX_COMPILER": "g++-15"    , "CMAKE_CXX_FLAGS": "-mavx2 -mfma" } },
+    { "name": "clang-bench"  , "inherits": ["unix-base"], "cacheVariables": { "CMAKE_CXX_COMPILER": "clang++-20", "CMAKE_CXX_FLAGS": "-mavx2 -mfma" } },
+
     { "name": "clang-macos"  , "inherits": ["unix-base"], "cacheVariables": { "CMAKE_CXX_COMPILER": "clang++"   , "CMAKE_CXX_FLAGS": "-O0 -DEVE_NO_FORCEINLINE" } },
     {
       "name": "clang-macos-libc++",
@@ -48,6 +51,8 @@
     { "name": "gcc-avx2"          , "inherits": "base-build", "configurePreset": "gcc-avx2"           },
     { "name": "clang"             , "inherits": "base-build", "configurePreset": "clang"              },
     { "name": "clang-avx2"        , "inherits": "base-build", "configurePreset": "clang-avx2"         },
+    { "name": "gcc-bench"          , "inherits": "base-build", "configurePreset": "gcc-bench"          },
+    { "name": "clang-bench"        , "inherits": "base-build", "configurePreset": "clang-bench"        },
     { "name": "clang-macos"       , "inherits": "base-build", "configurePreset": "clang-macos"        },
     { "name": "clang-macos-libc++", "inherits": "base-build", "configurePreset": "clang-macos-libc++" }
   ],
@@ -57,6 +62,8 @@
     { "name": "gcc-avx2"          , "inherits": "base-test", "configurePreset": "gcc-avx2"           },
     { "name": "clang"             , "inherits": "base-test", "configurePreset": "clang"              },
     { "name": "clang-avx2"        , "inherits": "base-test", "configurePreset": "clang-avx2"         },
+    { "name": "gcc-bench"          , "inherits": "base-test", "configurePreset": "gcc-bench"          },
+    { "name": "clang-bench"        , "inherits": "base-test", "configurePreset": "clang-bench"        },
     { "name": "clang-macos"       , "inherits": "base-test", "configurePreset": "clang-macos"        },
     { "name": "clang-macos-libc++", "inherits": "base-test", "configurePreset": "clang-macos-libc++" }
   ]

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -30,7 +30,7 @@ include(${CPM_DOWNLOAD_LOCATION})
 ##======================================================================================================================
 ## Retrieve dependencies
 ##======================================================================================================================
-CPMAddPackage ( NAME COPACABANA GITHUB_REPOSITORY jfalcou/copacabana  GIT_TAG main)
+CPMAddPackage ( NAME COPACABANA GITHUB_REPOSITORY jfalcou/copacabana  GIT_TAG v3)
 CPMAddPackage ( NAME TTS   GITHUB_REPOSITORY jfalcou/tts
                 GIT_TAG main
                 OPTIONS "TTS_BUILD_TEST OFF"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -25,4 +25,5 @@ copa_glob_unit( PATTERN "benchmarks/*.cpp"
                 RELATIVE  ${root}
                 INTERFACE kyosu_bench
                 PCH kyosu_bench_pch
+                TARGET kyosu-bench
               )


### PR DESCRIPTION
They sat in kyosu-test, so coverage would instrument 159 files that are not tests, and every pull request compiled them for no signal.

TARGET kyosu-bench keeps them out, which copacabana v3 makes possible. They now run on main only, in Release with AVX2 and FMA3 - the testing presets define EVE_NO_FORCEINLINE, which a Release build does not undo - and their output is aggregated into an artifact and the job summary.