### PR TITLE
Keep the dependencies' own tests out of the integration tests

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -3,9 +3,8 @@
 ## Copyright : KYOSU Contributors & Maintainers
 ## SPDX-License-Identifier: BSL-1.0
 ##======================================================================================================================
-## Benchmarks gate nothing, so they run once a change has landed rather than on every pull request,
-## where they were a quarter of the build for no signal. They also need their own presets: the ones
-## used for testing define EVE_NO_FORCEINLINE, which a Release build does not undo.
+## Benchmarks gate nothing, so they run once a change has landed. They need their own presets: the
+## testing ones define EVE_NO_FORCEINLINE, which a Release build does not undo.
 ##======================================================================================================================
 name: KYOSU Benchmarks
 on:

--- a/test/integration/fetch-test/CMakeLists.txt
+++ b/test/integration/fetch-test/CMakeLists.txt
@@ -21,6 +21,12 @@ FetchContent_Declare(eve
   GIT_TAG main
 )
 
+## FetchContent has no per-package OPTIONS: what the dependencies read is pinned here.
+set(KYOSU_BUILD_TEST        OFF CACHE BOOL "" FORCE)
+set(EVE_BUILD_TEST          OFF CACHE BOOL "" FORCE)
+set(EVE_BUILD_BENCHMARKS    OFF CACHE BOOL "" FORCE)
+set(EVE_BUILD_DOCUMENTATION OFF CACHE BOOL "" FORCE)
+
 # make available
 FetchContent_MakeAvailable(kyosu)
 FetchContent_MakeAvailable(eve)

--- a/test/integration/install-test/CMakeLists.txt
+++ b/test/integration/install-test/CMakeLists.txt
@@ -15,6 +15,11 @@ FetchContent_Declare(eve
   GIT_TAG main
 )
 
+## Nothing else populates eve here, so its options would stay at their defaults.
+set(EVE_BUILD_TEST          OFF CACHE BOOL "" FORCE)
+set(EVE_BUILD_BENCHMARKS    OFF CACHE BOOL "" FORCE)
+set(EVE_BUILD_DOCUMENTATION OFF CACHE BOOL "" FORCE)
+
 FetchContent_MakeAvailable(eve)
 
 find_package(kyosu CONFIG REQUIRED)


### PR DESCRIPTION
install-test and fetch-test never pinned the options their dependencies read, so eve registered its 1239 examples in one and kyosu its 510 in the other. The local workflow matches ctest on ^test_kyosu and hides it, so this only surfaces once kyosu moves to the shared workflow. cpm-test already carried its options in the file.