### PR TITLE
Pin copacabana to v4

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -13,7 +13,7 @@ include(${CMAKE_CURRENT_LIST_DIR}/CPM.cmake)
 ##======================================================================================================================
 ## Retrieve dependencies
 ##======================================================================================================================
-CPMAddPackage ( NAME COPACABANA GITHUB_REPOSITORY jfalcou/copacabana  GIT_TAG v3)
+CPMAddPackage ( NAME COPACABANA GITHUB_REPOSITORY jfalcou/copacabana  GIT_TAG v4)
 CPMAddPackage ( NAME TTS   GITHUB_REPOSITORY jfalcou/tts
                 GIT_TAG main
                 OPTIONS "TTS_BUILD_TEST OFF"


### PR DESCRIPTION
Cosmetic here: v3 to v4 only trims comments in the CMake modules. It keeps the pin from drifting further, since nothing maintains it automatically - Dependabot only rewrites the action references in the workflows.