### PR TITLE
Let Dependabot watch the pre-commit hooks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,3 +17,13 @@ updates:
         patterns:
           - "*"
     open-pull-requests-limit: 3
+
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      pre-commit:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 3


### PR DESCRIPTION
The hooks were pinned and nothing moved them: dependabot.yml only declared the github-actions ecosystem, so pre-commit-hooks sat on v2.3.0 and mirrors-clang-format on v19.1.7. Same grouped weekly configuration as the actions.