### PR TITLE
Pin eve to 95f0f26

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -21,7 +21,7 @@ CPMAddPackage ( NAME TTS   GITHUB_REPOSITORY jfalcou/tts
                         "TTS_QUIET ON"
               )
 CPMAddPackage ( NAME EVE   GITHUB_REPOSITORY jfalcou/eve
-                GIT_TAG main
+                GIT_TAG 95f0f2610e8f1009a9b4b15f4d7d78145eeb19c0
                 OPTIONS "EVE_BUILD_TEST OFF"
                         "EVE_BUILD_BENCHMARKS OFF"
                         "EVE_BUILD_DOCUMENTATION OFF"


### PR DESCRIPTION
eve #2377 changed its vendored kumi so any_of_ returns bool instead of auto. kyosu::is_not_finite feeds that into eve::as_logical_t, which does not convert on a SIMD argument. Every kyosu pull request fails on it since 14:45 today; main never says so because ci.yml only runs on pull_request.