### PR TITLE
Remove the debug printing left in the tests

### DIFF
--- a/include/kyosu/functions/exp.hpp
+++ b/include/kyosu/functions/exp.hpp
@@ -12,7 +12,6 @@
 #include <kyosu/functions/is_real.hpp>
 #include <kyosu/functions/is_not_finite.hpp>
 #include <kyosu/constants.hpp>
-#include <iostream>
 namespace kyosu
 {
   template<typename Options>

--- a/test/unit/function/bessel_hn.cpp
+++ b/test/unit/function/bessel_hn.cpp
@@ -177,7 +177,6 @@ TTS_CASE_TPL("Check kyosu::bessel_h1n integral positive order", kyosu::scalar_re
     auto fac = kyosu::sqrt(eve::pio_2(eve::as(kyosu::real(c))) * kyosu::rec(c));
     for (int i = 0; i < N; ++i)
     {
-      // std::cout<< "j " << j  << " c[" << i << "] = " << c << std::endl;
       auto res = kyosu::complex(reresN16[i][j], imresN16[i][j]);
       if (((i < 7) || (sizeof(T) == 8) ||
            kyosu::is_not_real(
@@ -364,7 +363,6 @@ TTS_CASE_TPL("Check kyosu::bessel_h2n integral negative order", kyosu::scalar_re
     auto fac = kyosu::sqrt(eve::pio_2(eve::as(kyosu::real(c))) * kyosu::rec(c));
     for (int i = 0; i < N; ++i)
     {
-      // std::cout<< "j " << j  << " c[" << i << "] = " << c << std::endl;
       auto res = kyosu::complex(reresN16[i][j], imresN16[i][j]);
       if (((i < 7) || (sizeof(T) == 8) ||
            kyosu::is_not_real(

--- a/test/unit/function/bessel_hr.cpp
+++ b/test/unit/function/bessel_hr.cpp
@@ -185,7 +185,6 @@ TTS_CASE_TPL("Check kyosu::bessel_hr over real positive order first kind", kyosu
       {
         auto res = kyosu::complex(reresN16[i][j], imresN16[i][j]);
         auto v = v0 + i;
-        //       std::cout<< "j " << j  << " c[" << j << "] = " << c << " i " << i << " v " << v << std::endl;
         TTS_RELATIVE_EQUAL(kyosu::bessel_h(v, c), res, tts::prec<T>());
         TTS_RELATIVE_EQUAL(kyosu::bessel_h[spherical](v, c), kyosu::bessel_h(v + h, c) * fac, tts::prec<T>());
         if (i < 5)
@@ -371,7 +370,6 @@ TTS_CASE_TPL("Check kyosu::bessel_hr over real positive order second kind", kyos
     {
       auto res = kyosu::complex(reresN16[i][j], imresN16[i][j]);
       auto v = v0 + i;
-      //      std::cout<< "j " << j  << " c[" << j << "] = " << c << " i " << i << " v " << v << std::endl;
       if (((i < 7) || (sizeof(T) == 8) ||
            kyosu::is_not_real(
              c))) // The limitation of these tests with float is due to some overflow pbs when z is real

--- a/test/unit/function/bessel_in.cpp
+++ b/test/unit/function/bessel_in.cpp
@@ -180,7 +180,6 @@ TTS_CASE_TPL("Check kyosu::cyl_bessel_jn over real", kyosu::scalar_real_types)
     auto fac = kyosu::sqrt(eve::pio_2(eve::as(kyosu::real(c))) * kyosu::rec(c));
     for (int i = 0; i < N; ++i)
     {
-      // std::cout<< "j " << j  << " c[" << i << "] = " << c << std::endl;
       auto res = kyosu::complex(reresN16[i][j], imresN16[i][j]);
       TTS_RELATIVE_EQUAL(kyosu::bessel_i(i, c), res, tts::prec<T>());
       TTS_RELATIVE_EQUAL(kyosu::bessel_i(-i, c), res, tts::prec<T>());

--- a/test/unit/function/bessel_ir.cpp
+++ b/test/unit/function/bessel_ir.cpp
@@ -185,7 +185,6 @@ TTS_CASE_TPL("Check kyosu::bessel_ir over real positive order", kyosu::scalar_re
       {
         auto res = kyosu::complex(reresN16[i][j], imresN16[i][j]);
         auto v = v0 + i;
-        //       std::cout<< "j " << j  << " c[" << j << "] = " << c << " i " << i << " v " << v << std::endl;
         TTS_RELATIVE_EQUAL(kyosu::bessel_i(v, c), res, tts::prec<T>());
         TTS_RELATIVE_EQUAL(kyosu::bessel_i[spherical](v, c), kyosu::bessel_i(v + h, c) * fac, tts::prec<T>());
         if (i < 5)
@@ -371,7 +370,6 @@ TTS_CASE_TPL("Check kyosu::bessel_ir over real negative order", kyosu::scalar_re
     {
       auto res = kyosu::complex(reresN16[i][j], imresN16[i][j]);
       auto v = v0 - i;
-      // std::cout<< "j " << j  << " c[" << j << "] = " << c << " i " << i << " v " << v << std::endl;
       if (((i < 7) || (sizeof(T) == 8) ||
            kyosu::is_not_real(
              c))) // The limitation of these tests with float is due to some overflow pbs when z is real

--- a/test/unit/function/bessel_jn.cpp
+++ b/test/unit/function/bessel_jn.cpp
@@ -137,7 +137,6 @@ TTS_CASE_TPL("Check kyosu::cyl_bessel_jn over real", kyosu::scalar_real_types)
     auto fac = kyosu::sqrt(eve::pio_2(eve::as(kyosu::real(c))) * kyosu::rec(c));
     for (int i = 0; i < N; ++i)
     {
-      // std::cout<< "j " << j  << " c[" << i << "] = " << c << std::endl;
       auto res = kyosu::complex(reresN16[i][j], imresN16[i][j]);
       TTS_RELATIVE_EQUAL(kyosu::bessel_j(i, c), res, tts::prec<T>());
       TTS_RELATIVE_EQUAL(kyosu::bessel_j(-i, c), eve::sign_alternate(i) * res, tts::prec<T>());

--- a/test/unit/function/bessel_jr.cpp
+++ b/test/unit/function/bessel_jr.cpp
@@ -185,7 +185,6 @@ TTS_CASE_TPL("Check kyosu::bessel_jr over real positive order", kyosu::scalar_re
       {
         auto res = kyosu::complex(reresN16[i][j], imresN16[i][j]);
         auto v = v0 + i;
-        //       std::cout<< "j " << j  << " c[" << j << "] = " << c << " i " << i << " v " << v << std::endl;
         TTS_RELATIVE_EQUAL(kyosu::bessel_j(v, c), res, tts::prec<T>());
         TTS_RELATIVE_EQUAL(kyosu::bessel_j[spherical](v, c), kyosu::bessel_j(v + h, c) * fac, tts::prec<T>());
         if (i < 5)
@@ -371,7 +370,6 @@ TTS_CASE_TPL("Check kyosu::bessel_jr over real negative order", kyosu::scalar_re
     {
       auto res = kyosu::complex(reresN16[i][j], imresN16[i][j]);
       auto v = v0 - i;
-      // std::cout<< "j " << j  << " c[" << j << "] = " << c << " i " << i << " v " << v << std::endl;
       if (((i < 7) || (sizeof(T) == 8) ||
            kyosu::is_not_real(
              c))) // The limitation of these tests with float is due to some overflow pbs when z is real

--- a/test/unit/function/bessel_kn.cpp
+++ b/test/unit/function/bessel_kn.cpp
@@ -178,7 +178,6 @@ TTS_CASE_TPL("Check kyosu::cyl_bessel_kn integral  order", kyosu::scalar_real_ty
     auto fac = kyosu::sqrt(eve::pio_2(eve::as(kyosu::real(c))) * kyosu::rec(c));
     for (int i = 0; i < N; ++i)
     {
-      // std::cout<< "j " << j  << " c[" << i << "] = " << c << std::endl;
       auto res = kyosu::complex(reresN16[i][j], imresN16[i][j]);
       if (((i < 7) || (sizeof(T) == 8) ||
            kyosu::is_not_real(

--- a/test/unit/function/bessel_kr.cpp
+++ b/test/unit/function/bessel_kr.cpp
@@ -185,7 +185,6 @@ TTS_CASE_TPL("Check kyosu::bessel_kr over real positive order", kyosu::scalar_re
       {
         auto res = kyosu::complex(reresN16[i][j], imresN16[i][j]);
         auto v = v0 + i;
-        //       std::cout<< "j " << j  << " c[" << j << "] = " << c << " i " << i << " v " << v << std::endl;
         TTS_RELATIVE_EQUAL(kyosu::bessel_k(v, c), res, tts::prec<T>());
         TTS_RELATIVE_EQUAL(kyosu::bessel_k(-v, c), res, tts::prec<T>());
         TTS_RELATIVE_EQUAL(kyosu::bessel_k[spherical](v, c), kyosu::bessel_k(v + h, c) * fac, tts::prec<T>());

--- a/test/unit/function/bessel_yn.cpp
+++ b/test/unit/function/bessel_yn.cpp
@@ -180,7 +180,6 @@ TTS_CASE_TPL("Check kyosu::cyl_bessel_yn over real", kyosu::scalar_real_types)
     auto fac = kyosu::sqrt(eve::pio_2(eve::as(kyosu::real(c))) * kyosu::rec(c));
     for (int i = 0; i < N; ++i)
     {
-      //      std::cout<< "i " << i  << "j " << j  << " c[" << i << "] = " << c << std::endl;
       auto res = kyosu::complex(reresN16[i][j], imresN16[i][j]);
       if (((i < 7) || (sizeof(T) == 8) ||
            kyosu::is_not_real(

--- a/test/unit/function/bessel_yr.cpp
+++ b/test/unit/function/bessel_yr.cpp
@@ -186,7 +186,6 @@ TTS_CASE_TPL("Check kyosu::bessel_yr over real positive order", kyosu::scalar_re
       {
         auto res = kyosu::complex(reresN16[i][j], imresN16[i][j]);
         auto v = v0 + i;
-        //       std::cout<< "j " << j  << " c[" << j << "] = " << c << " i " << i << " v " << v << std::endl;
         TTS_RELATIVE_EQUAL(kyosu::bessel_y(v, c), res, tts::prec<T>());
         TTS_RELATIVE_EQUAL(kyosu::bessel_y[spherical](v, c), kyosu::bessel_y(v + h, c) * fac, tts::prec<T>());
         if (i < 5)
@@ -372,7 +371,6 @@ TTS_CASE_TPL("Check kyosu::bessel_yr over real negative order", kyosu::scalar_re
     {
       auto res = kyosu::complex(reresN16[i][j], imresN16[i][j]);
       auto v = v0 - i;
-      // std::cout<< "j " << j  << " c[" << j << "] = " << c << " i " << i << " v " << v << std::endl;
       if (((i < 7) || (sizeof(T) == 8) ||
            kyosu::is_not_real(
              c))) // The limitation of these tests with float is due to some overflow pbs when z is real

--- a/test/unit/function/is_fnan.cpp
+++ b/test/unit/function/is_fnan.cpp
@@ -20,7 +20,6 @@ TTS_CASE_WITH("Check kyosu::is_fnan over complex", kyosu::real_types, tts::rando
   using T = kyosu::complex_t<decltype(r)>;
   TTS_EQUAL(kyosu::is_fnan(kyosu::complex(r, i)), eve::is_nan(r) && eve::is_nan(i));
   auto z(kyosu::nan(eve::as<T>()));
-  std::cout << "z " << z << std::endl;
   TTS_EQUAL(kyosu::is_fnan(z), eve::false_(eve::as(r)));
   auto zz = kyosu::complex(eve::nan(eve::as(r)), eve::nan(eve::as(r)));
   TTS_EQUAL(kyosu::is_fnan(zz), eve::true_(eve::as(r)));

--- a/test/unit/function/is_not_fnan.cpp
+++ b/test/unit/function/is_not_fnan.cpp
@@ -20,7 +20,6 @@ TTS_CASE_WITH("Check kyosu::is_not_fnan over complex", kyosu::real_types, tts::r
   using T = kyosu::complex_t<decltype(r)>;
   TTS_EQUAL(kyosu::is_not_fnan(kyosu::complex(r, i)), eve::is_not_nan(r) || eve::is_not_nan(i));
   auto z(kyosu::nan(eve::as<T>()));
-  std::cout << "z " << z << std::endl;
   TTS_EQUAL(kyosu::is_not_fnan(z), eve::true_(eve::as(r)));
   auto zz = kyosu::complex(eve::nan(eve::as(r)), eve::nan(eve::as(r)));
   TTS_EQUAL(kyosu::is_not_fnan(zz), eve::false_(eve::as(r)));

--- a/test/unit/function/manhattan.cpp
+++ b/test/unit/function/manhattan.cpp
@@ -13,11 +13,6 @@ TTS_CASE_WITH("Check kyosu::manhattan over real", kyosu::real_types, tts::random
 )
 (auto r0, auto r1)
 {
-  using e_t = eve::element_type_t<decltype(r0)>;
-  std::cout << eve::manhattan(r0, eve::one(eve::as(r0))) << std::endl;
-  std::cout << kyosu::manhattan(r0, eve::one(eve::as(r0))) << std::endl;
-  std::cout << kyosu::manhattan(r0, eve::one(eve::as<e_t>())) << std::endl;
-  std::cout << kyosu::manhattan(r0, kyosu::complex(r1)) << std::endl;
   //  TTS_EQUAL(kyosu::manhattan(r0, kyosu::complex(r1)), eve::manhattan(r0, r1));
   //  TTS_EQUAL(kyosu::manhattan(kyosu::complex(r0),  r1), eve::manhattan(r0, r1));
   TTS_EQUAL(kyosu::manhattan(r0, r1), eve::manhattan(r0, r1));


### PR DESCRIPTION
exp.hpp carried an <iostream> it never used, and thirteen unit tests printed to the console: fifteen of those lines were already commented out, six were still live. The two in is_fnan and is_not_fnan sat between assertions, and four in manhattan replaced the assertions rather than accompanying them.

Those thirteen tests use std::cout without including <iostream> themselves, so they were compiling on the include exp.hpp dragged in through kyosu.hpp. Dropping the printing is what makes dropping the include safe.

manhattan also loses a typedef that only the printing used. The two assertions commented out above it are left alone: restoring them is a separate question.