### PR TITLE
Fix slerp interpolating from the wrong end

### DIFF
--- a/include/kyosu/functions/slerp.hpp
+++ b/include/kyosu/functions/slerp.hpp
@@ -86,6 +86,6 @@ namespace kyosu::_
     }
     auto gez = eve::is_gez(real(kyosu::dot(z0, z1)));
     auto mix = kyosu::if_else(gez, z1, -z1);
-    return z1 * kyosu::pow(kyosu::conj(z1) * mix, z2);
+    return z0 * kyosu::pow(kyosu::conj(z0) * mix, z2);
   }
 }

--- a/include/kyosu/functions/slerp.hpp
+++ b/include/kyosu/functions/slerp.hpp
@@ -86,7 +86,8 @@ namespace kyosu::_
       z1 = kyosu::signnz(z1);
     }
     // The mask can be wider than what it masks - a wide z0 against a scalar z1 - and a masked call
-    // answers the type of its argument, so z1 goes up to the call's own return type first.
+    // answers the type of its argument, so z1 goes up to the call's own return type first. That last
+    // step is eve#2381: it can go once if_else stops ignoring the width of its mask.
     using r_t = as_cayley_dickson_like_t<complexify_t<Z0>, complexify_t<Z1>, Z2>;
     auto gez = eve::is_gez(real(kyosu::dot(z0, z1)));
     auto mix = kyosu::minus[!gez](r_t(z1));

--- a/include/kyosu/functions/slerp.hpp
+++ b/include/kyosu/functions/slerp.hpp
@@ -10,6 +10,7 @@
 #include <kyosu/functions/to_complex.hpp>
 #include <kyosu/functions/pow.hpp>
 #include <kyosu/functions/is_unitary.hpp>
+#include <kyosu/functions/minus.hpp>
 #include <kyosu/functions/signnz.hpp>
 #include <kyosu/functions/conj.hpp>
 #include <kyosu/details/decorators.hpp>
@@ -84,8 +85,11 @@ namespace kyosu::_
       z0 = kyosu::signnz(z0);
       z1 = kyosu::signnz(z1);
     }
+    // The mask can be wider than what it masks - a wide z0 against a scalar z1 - and a masked call
+    // answers the type of its argument, so z1 goes up to the call's own return type first.
+    using r_t = as_cayley_dickson_like_t<complexify_t<Z0>, complexify_t<Z1>, Z2>;
     auto gez = eve::is_gez(real(kyosu::dot(z0, z1)));
-    auto mix = kyosu::if_else(gez, z1, -z1);
+    auto mix = kyosu::minus[!gez](r_t(z1));
     return z0 * kyosu::pow(kyosu::conj(z0) * mix, z2);
   }
 }

--- a/test/unit/quaternion/slerp.cpp
+++ b/test/unit/quaternion/slerp.cpp
@@ -1,0 +1,59 @@
+//======================================================================================================================
+/*
+  Kyosu - Complex Without Complexes
+  Copyright : KYOSU Contributors & Maintainers
+  SPDX-License-Identifier: BSL-1.0
+*/
+//======================================================================================================================
+#include "test.hpp"
+#include <kyosu/kyosu.hpp>
+
+TTS_CASE_WITH("Check that slerp reaches both ends of the arc",
+              kyosu::real_types,
+              tts::randoms(-1., +1.),
+              tts::randoms(-1., +1.),
+              tts::randoms(-1., +1.),
+              tts::randoms(-1., +1.))
+<typename T>(T const& a, T const& b, T const& c, T const& d)
+{
+  auto z0 = kyosu::sign(kyosu::quaternion_t<T>(a, b, c, d));
+  auto z1 = kyosu::sign(kyosu::quaternion_t<T>(d, c, b, a));
+
+  // q and -q denote the same rotation, and slerp takes the shortest arc, so the ends are
+  // recovered up to sign. |dot| is what distinguishes a rotation from its representation.
+  TTS_RELATIVE_EQUAL(kyosu::abs(kyosu::dot(kyosu::slerp(z0, z1, T(0)), z0)), T(1), tts::prec<T>());
+  TTS_RELATIVE_EQUAL(kyosu::abs(kyosu::dot(kyosu::slerp(z0, z1, T(1)), z1)), T(1), tts::prec<T>());
+};
+
+TTS_CASE_WITH("Check that slerp walks the arc at constant angular speed", kyosu::real_types, tts::randoms(0.1, 1.0))
+<typename T>(T const& angle)
+{
+  auto ax = std::array<T, 3>{T(0), T(0), T(1)};
+  auto z0 = kyosu::from_angle_axis(T(0), std::span(ax));
+  auto z1 = kyosu::from_angle_axis(angle, std::span(ax));
+
+  // Halfway along the arc is the rotation of half the angle.
+  auto mid = kyosu::from_angle_axis(angle / 2, std::span(ax));
+  TTS_RELATIVE_EQUAL(kyosu::slerp(z0, z1, T(0.5)), mid, tts::prec<T>());
+
+  // And each quarter advances by the same amount.
+  auto q1 = kyosu::slerp(z0, z1, T(0.25));
+  auto q3 = kyosu::slerp(z0, z1, T(0.75));
+  TTS_RELATIVE_EQUAL(kyosu::from_angle_axis(angle / 4, std::span(ax)), q1, tts::prec<T>());
+  TTS_RELATIVE_EQUAL(kyosu::from_angle_axis(angle * T(0.75), std::span(ax)), q3, tts::prec<T>());
+};
+
+TTS_CASE_WITH("Check that slerp takes the shortest arc",
+              kyosu::real_types,
+              tts::randoms(-1., +1.),
+              tts::randoms(-1., +1.),
+              tts::randoms(-1., +1.),
+              tts::randoms(-1., +1.))
+<typename T>(T const& a, T const& b, T const& c, T const& d)
+{
+  auto z0 = kyosu::sign(kyosu::quaternion_t<T>(a, b, c, d));
+  auto z1 = kyosu::sign(kyosu::quaternion_t<T>(d, c, b, a));
+
+  // q and -q are the same rotation, so both must be interpolated the same way.
+  TTS_RELATIVE_EQUAL(kyosu::slerp(z0, z1, T(0.5)), kyosu::slerp(z0, -z1, T(0.5)), tts::prec<T>());
+};


### PR DESCRIPTION
slerp returned z1 for every value of t. The last line of slerp_ read

    return z1 * pow(conj(z1) * mix, z2);

where both occurrences should name z0. For a unit quaternion conj(z1) * z1 is one, so pow raised one to the power t and the whole expression collapsed to z1, whatever t was asked for.

The function had no unit test — only a documentation example that prints values without checking any of them, which is how this survived. The three cases added here check that both ends of the arc are reached, that the midpoint and quarter points are the rotations of the corresponding fractions of the angle, and that q and -q interpolate alike. Eighteen of their thirty-six instantiations fail against the previous implementation.

The endpoints are compared through the absolute dot product rather than componentwise: slerp takes the shortest arc, so it may return the antipodal representative, and q and -q denote the same rotation.