### PR TITLE
Issue #87 - Complexify a masked real before the call, and test it

### DIFF
--- a/include/kyosu/details/callable.hpp
+++ b/include/kyosu/details/callable.hpp
@@ -8,6 +8,8 @@
 #pragma once
 
 #include <kyosu/details/abi.hpp>
+#include <kyosu/types/concepts.hpp>
+#include <kyosu/types/traits.hpp>
 #include <eve/traits/overload.hpp>
 
 namespace kyosu::_
@@ -19,3 +21,86 @@ namespace kyosu::_
 #define KYOSU_CALLABLE_OBJECT(TYPE, NAME) EVE_CALLABLE_OBJECT_FROM(kyosu::_, TYPE, NAME)
 #define KYOSU_CALL(...) EVE_DISPATCH_CALL(__VA_ARGS__)
 #define KYOSU_DELAY() EVE_REQUIRES(eve::cpu_)
+
+namespace kyosu
+{
+  namespace _
+  {
+    //==================================================================================================================
+    // Sits between a kyosu callable and the eve base it would otherwise derive from, and overrides behavior(), the
+    // entry point eve dispatches every call through.
+    //
+    // eve computes f[cond](x) as if_else(cond, f(x), x): the lanes cond rejects carry x itself, so x and f(x) have to
+    // share a type. They do not when f answers a complex to a real argument - kyosu::sqrt(-1.0) is a complex where x
+    // is a double - and eve cannot turn a wide<double> into a wide<complex<double>> on its own.
+    //
+    // Promoting x to complexify_t<T> before Base::behavior() runs makes both sides complex, and eve hands the
+    // promoted x back untouched.
+    //
+    // The promotion is unconditional, and that is deliberate: deciding it from the type Base::behavior() answers
+    // would mean instantiating it inside this one, which eve also calls under is_invocable when it aggregates a
+    // wide - turning "not invocable" into a hard error. A callable that answers a real must therefore keep its eve
+    // base rather than this one.
+    //==================================================================================================================
+    template<typename Base> struct promoting_callable : Base
+    {
+      template<eve::callable_options O, typename T, typename... Ts>
+      KYOSU_FORCEINLINE constexpr auto behavior(auto arch, O const& opts, T x0, Ts... xs) const
+      {
+        constexpr bool masked =
+          O::contains(eve::condition_key) && !eve::match_option<eve::condition_key, O, eve::ignore_none_>;
+
+        if constexpr (masked && concepts::real<T>) return Base::behavior(arch, opts, complexify_t<T>(x0), xs...);
+        else return Base::behavior(arch, opts, x0, xs...);
+      }
+    };
+  }
+
+  //====================================================================================================================
+  //! @addtogroup traits
+  //! @{
+  //====================================================================================================================
+
+  //====================================================================================================================
+  //! @struct promoting_elementwise_callable
+  //! @brief CRTP base for a kyosu callable that answers a complex to a real argument.
+  //!
+  //! Behaves as eve::elementwise_callable, which it derives from, and promotes a real argument to its complex
+  //! counterpart when the call carries a condition. A masked call answers its own argument on the lanes the condition
+  //! rejects, so the two have to share a type.
+  //!
+  //! Use it for a callable whose return type is complexify_t or complexify_if_t. One that answers a real - abs, arg -
+  //! keeps eve::elementwise_callable: promoting its argument would create the very mismatch this removes. One that
+  //! cannot honour a condition at all uses eve::callable, which refuses `operator[]`.
+  //!
+  //! @tparam Func          The callable being defined
+  //! @tparam OptionsValues Type of the stored options
+  //! @tparam Options       List of supported option specifications
+  //====================================================================================================================
+  template<template<typename> class Func, typename OptionsValues, typename... Options>
+  struct promoting_elementwise_callable
+    : _::promoting_callable<eve::elementwise_callable<Func, OptionsValues, Options...>>
+  {
+  };
+
+  //====================================================================================================================
+  //! @struct promoting_strict_elementwise_callable
+  //! @brief The eve::strict_elementwise_callable counterpart of kyosu::promoting_elementwise_callable.
+  //!
+  //! Same promotion of a masked real argument, without the common-type conversion eve applies to arguments of
+  //! differing types.
+  //!
+  //! @tparam Func          The callable being defined
+  //! @tparam OptionsValues Type of the stored options
+  //! @tparam Options       List of supported option specifications
+  //====================================================================================================================
+  template<template<typename> class Func, typename OptionsValues, typename... Options>
+  struct promoting_strict_elementwise_callable
+    : _::promoting_callable<eve::strict_elementwise_callable<Func, OptionsValues, Options...>>
+  {
+  };
+
+  //====================================================================================================================
+  //! @}
+  //====================================================================================================================
+}

--- a/include/kyosu/functions/acsch.hpp
+++ b/include/kyosu/functions/acsch.hpp
@@ -13,7 +13,8 @@
 
 namespace kyosu
 {
-  template<typename Options> struct acsch_t : eve::elementwise_callable<acsch_t, Options, raw_option, pedantic_option>
+  template<typename Options>
+  struct acsch_t : kyosu::promoting_elementwise_callable<acsch_t, Options, raw_option, pedantic_option>
   {
     template<concepts::cayley_dickson_like Z>
     KYOSU_FORCEINLINE constexpr complexify_if_t<Options, Z> operator()(Z const& z) const noexcept

--- a/include/kyosu/functions/asech.hpp
+++ b/include/kyosu/functions/asech.hpp
@@ -14,7 +14,8 @@
 namespace kyosu
 {
   template<typename Options>
-  struct asech_t : eve::elementwise_callable<asech_t, Options, raw_option, pedantic_option, real_only_option>
+  struct asech_t
+    : kyosu::promoting_elementwise_callable<asech_t, Options, raw_option, pedantic_option, real_only_option>
   {
     template<concepts::cayley_dickson_like Z>
     KYOSU_FORCEINLINE constexpr complexify_if_t<Options, Z> operator()(Z const& z) const noexcept

--- a/include/kyosu/functions/asech.hpp
+++ b/include/kyosu/functions/asech.hpp
@@ -93,10 +93,7 @@ namespace kyosu::_
     if constexpr (O::contains(real_only)) return eve::asech(z);
     // The real asech only answers on (0, 1]. Anywhere else the value is complex, so the argument goes up to the
     // complex plane and acosh finds it there, the way sqrt, acos, asin and acosh all do for a real of their own.
-    //
-    // The reciprocal is taken while the argument is still real: the complex rec hands acosh a negative zero for the
-    // imaginary part, which lands on the far side of its branch cut over (-1, 1) and answers the conjugate.
-    else if constexpr (concepts::real<Z>) return kyosu::acosh[o](complex(eve::rec(z)));
+    else if constexpr (concepts::real<Z>) return kyosu::acosh[o](kyosu::rec(complex(z)));
     else return kyosu::acosh[o](kyosu::rec(z));
   }
 

--- a/include/kyosu/functions/asech.hpp
+++ b/include/kyosu/functions/asech.hpp
@@ -91,7 +91,12 @@ namespace kyosu::_
   KYOSU_FORCEINLINE constexpr auto asech_(KYOSU_DELAY(), O const& o, Z z) noexcept
   {
     if constexpr (O::contains(real_only)) return eve::asech(z);
-    else if constexpr (concepts::real<Z>) return kyosu::inject[real_only](eve::asech(z));
+    // The real asech only answers on (0, 1]. Anywhere else the value is complex, so the argument goes up to the
+    // complex plane and acosh finds it there, the way sqrt, acos, asin and acosh all do for a real of their own.
+    //
+    // The reciprocal is taken while the argument is still real: the complex rec hands acosh a negative zero for the
+    // imaginary part, which lands on the far side of its branch cut over (-1, 1) and answers the conjugate.
+    else if constexpr (concepts::real<Z>) return kyosu::acosh[o](complex(eve::rec(z)));
     else return kyosu::acosh[o](kyosu::rec(z));
   }
 

--- a/include/kyosu/functions/atanh.hpp
+++ b/include/kyosu/functions/atanh.hpp
@@ -107,13 +107,19 @@ namespace kyosu
 namespace kyosu::_
 {
   template<typename Z, eve::callable_options O>
-  KYOSU_NOINLINE constexpr auto atanh_(KYOSU_DELAY(), O const&, Z a0) noexcept
+  KYOSU_NOINLINE constexpr auto atanh_(KYOSU_DELAY(), O const& o, Z a0) noexcept
   {
     if constexpr (O::contains(real_only)) return eve::atanh(a0);
-    else if constexpr (concepts::real<Z>) return kyosu::inject[real_only](eve::atanh(a0));
+    // The real atanh only answers on (-1, 1); anywhere else the value is complex, and injecting the real one would
+    // carry its nan into the complex plane rather than the value that exists there.
+    else if constexpr (concepts::real<Z>) return kyosu::atanh[o](complex(a0));
     else if constexpr (concepts::complex<Z>)
     {
-      if (eve::all(is_real(a0))) return kyosu::inject(eve::atanh(real(a0)));
+      // Same domain, so the shortcut to the real atanh only holds on it - the closed interval, the two ends included:
+      // there the real atanh is the infinity the complex one answers too.
+      auto re = real(a0);
+      if (eve::all(is_real(a0) && eve::is_less_equal(eve::abs(re), eve::one(eve::as(re)))))
+        return kyosu::inject(eve::atanh(re));
       // This implementation is a simd (i.e. no branching) transcription and adaptation of the
       // boost_math code which itself is a transcription of the pseudo-code in:
       //

--- a/include/kyosu/functions/digamma.hpp
+++ b/include/kyosu/functions/digamma.hpp
@@ -13,7 +13,7 @@
 namespace kyosu
 {
   template<typename Options>
-  struct digamma_t : eve::elementwise_callable<digamma_t, Options, raw_option, pedantic_option>
+  struct digamma_t : kyosu::promoting_elementwise_callable<digamma_t, Options, raw_option, pedantic_option>
   {
     template<concepts::cayley_dickson_like Z>
     KYOSU_FORCEINLINE constexpr complexify_t<Z> operator()(Z const& z) const noexcept

--- a/include/kyosu/functions/erfi.hpp
+++ b/include/kyosu/functions/erfi.hpp
@@ -14,7 +14,8 @@
 
 namespace kyosu
 {
-  template<typename Options> struct erfi_t : eve::elementwise_callable<erfi_t, Options, raw_option, pedantic_option>
+  template<typename Options>
+  struct erfi_t : kyosu::promoting_elementwise_callable<erfi_t, Options, raw_option, pedantic_option>
   {
     template<concepts::cayley_dickson_like Z>
     KYOSU_FORCEINLINE constexpr complexify_t<Z> operator()(Z const& z) const noexcept

--- a/include/kyosu/functions/exp_i.hpp
+++ b/include/kyosu/functions/exp_i.hpp
@@ -13,7 +13,7 @@
 namespace kyosu
 {
   template<typename Options>
-  struct exp_i_t : eve::elementwise_callable<exp_i_t, Options, radpi_option, raw_option, pedantic_option>
+  struct exp_i_t : kyosu::promoting_elementwise_callable<exp_i_t, Options, radpi_option, raw_option, pedantic_option>
   {
     template<concepts::cayley_dickson_like Z>
     KYOSU_FORCEINLINE constexpr complexify_t<Z> operator()(Z const& z) const noexcept

--- a/include/kyosu/functions/expx2.hpp
+++ b/include/kyosu/functions/expx2.hpp
@@ -12,7 +12,8 @@
 
 namespace kyosu
 {
-  template<typename Options> struct expx2_t : eve::elementwise_callable<expx2_t, Options, raw_option, pedantic_option>
+  template<typename Options>
+  struct expx2_t : kyosu::promoting_elementwise_callable<expx2_t, Options, raw_option, pedantic_option>
   {
     template<concepts::cayley_dickson_like Z>
     KYOSU_FORCEINLINE constexpr complexify_if_t<Options, Z> operator()(Z const& z) const noexcept

--- a/include/kyosu/functions/faddeeva.hpp
+++ b/include/kyosu/functions/faddeeva.hpp
@@ -12,7 +12,7 @@
 namespace kyosu
 {
   template<typename Options>
-  struct faddeeva_t : eve::elementwise_callable<faddeeva_t, Options, raw_option, pedantic_option>
+  struct faddeeva_t : kyosu::promoting_elementwise_callable<faddeeva_t, Options, raw_option, pedantic_option>
   {
     template<concepts::cayley_dickson_like Z>
     KYOSU_FORCEINLINE constexpr complexify_t<Z> operator()(Z const& z) const noexcept

--- a/include/kyosu/functions/muli.hpp
+++ b/include/kyosu/functions/muli.hpp
@@ -12,8 +12,12 @@
 namespace kyosu
 {
   template<typename Options>
-  struct muli_t
-    : eve::elementwise_callable<muli_t, Options, raw_option, pedantic_option, eve::left_option, eve::right_option>
+  struct muli_t : kyosu::promoting_elementwise_callable<muli_t,
+                                                        Options,
+                                                        raw_option,
+                                                        pedantic_option,
+                                                        eve::left_option,
+                                                        eve::right_option>
   {
     template<concepts::cayley_dickson_like Z>
     KYOSU_FORCEINLINE constexpr complexify_t<Z> operator()(Z const& z) const noexcept

--- a/include/kyosu/functions/mulmi.hpp
+++ b/include/kyosu/functions/mulmi.hpp
@@ -12,8 +12,12 @@
 namespace kyosu
 {
   template<typename Options>
-  struct mulmi_t
-    : eve::elementwise_callable<mulmi_t, Options, raw_option, pedantic_option, eve::left_option, eve::right_option>
+  struct mulmi_t : kyosu::promoting_elementwise_callable<mulmi_t,
+                                                         Options,
+                                                         raw_option,
+                                                         pedantic_option,
+                                                         eve::left_option,
+                                                         eve::right_option>
   {
     template<concepts::cayley_dickson_like Z>
     KYOSU_FORCEINLINE constexpr complexify_t<Z> operator()(Z const& z) const noexcept

--- a/include/kyosu/functions/omega.hpp
+++ b/include/kyosu/functions/omega.hpp
@@ -13,7 +13,8 @@
 
 namespace kyosu
 {
-  template<typename Options> struct omega_t : eve::elementwise_callable<omega_t, Options, raw_option, pedantic_option>
+  template<typename Options>
+  struct omega_t : kyosu::promoting_elementwise_callable<omega_t, Options, raw_option, pedantic_option>
   {
     template<concepts::cayley_dickson_like Z>
     KYOSU_FORCEINLINE constexpr complexify_t<Z> operator()(Z const& z) const noexcept

--- a/include/kyosu/functions/slerp.hpp
+++ b/include/kyosu/functions/slerp.hpp
@@ -18,7 +18,7 @@ namespace kyosu
 {
   template<typename Options>
   struct slerp_t
-    : eve::strict_elementwise_callable<slerp_t, Options, raw_option, pedantic_option, assume_unitary_option>
+    : kyosu::promoting_strict_elementwise_callable<slerp_t, Options, raw_option, pedantic_option, assume_unitary_option>
   {
     template<concepts::cayley_dickson_like Z0, concepts::cayley_dickson_like Z1, concepts::real Z2>
     requires(eve::same_lanes_or_scalar<Z0, Z1, Z2>)

--- a/include/kyosu/functions/tricomi.hpp
+++ b/include/kyosu/functions/tricomi.hpp
@@ -21,7 +21,7 @@
 namespace kyosu
 {
   template<typename Options>
-  struct tricomi_t : eve::strict_elementwise_callable<tricomi_t, Options, raw_option, pedantic_option>
+  struct tricomi_t : kyosu::promoting_strict_elementwise_callable<tricomi_t, Options, raw_option, pedantic_option>
   {
     template<concepts::complex_like Z, concepts::complex_like T1, concepts::complex_like T2>
     constexpr KYOSU_FORCEINLINE as_cayley_dickson_t<complexify_t<Z>, T1, T2> operator()(Z z, T1 a, T2 b) const noexcept

--- a/include/kyosu/functions/xi.hpp
+++ b/include/kyosu/functions/xi.hpp
@@ -15,7 +15,8 @@
 namespace kyosu
 {
   template<typename Options>
-  struct xi_t : eve::elementwise_callable<xi_t, Options, raw_option, pedantic_option, riemann_option, landau_option>
+  struct xi_t
+    : kyosu::promoting_elementwise_callable<xi_t, Options, raw_option, pedantic_option, riemann_option, landau_option>
   {
     template<concepts::cayley_dickson_like Z>
     KYOSU_FORCEINLINE constexpr complexify_t<Z> operator()(Z const& z) const noexcept

--- a/include/kyosu/functions/zeta.hpp
+++ b/include/kyosu/functions/zeta.hpp
@@ -13,7 +13,8 @@
 
 namespace kyosu
 {
-  template<typename Options> struct zeta_t : eve::elementwise_callable<zeta_t, Options, raw_option, pedantic_option>
+  template<typename Options>
+  struct zeta_t : kyosu::promoting_elementwise_callable<zeta_t, Options, raw_option, pedantic_option>
   {
     template<concepts::cayley_dickson_like Z>
     KYOSU_FORCEINLINE constexpr complexify_t<Z> operator()(Z const& z) const noexcept

--- a/test/unit/complex/digamma.cpp
+++ b/test/unit/complex/digamma.cpp
@@ -39,3 +39,15 @@ TTS_CASE_TPL("Check log_abs_gamma", kyosu::real_types)
   TTS_RELATIVE_EQUAL(kyosu::digamma(tcx(-1, -1)), tcx(0.594650320622477, -2.576674047468582), tts::prec<T>());
   ;
 };
+
+//======================================================================================================================
+//== A masked call answers a complex where its argument was real, so the lanes the condition rejects carry complex(v)
+//======================================================================================================================
+TTS_CASE_WITH("Check kyosu::digamma over a masked real", kyosu::real_types, tts::randoms(0.5, 5.0))
+<typename T>(T v)
+{
+  auto cond = eve::is_greater(v, T(2.5));
+
+  TTS_RELATIVE_EQUAL(kyosu::digamma[cond](v), kyosu::if_else(cond, kyosu::digamma(v), kyosu::complex_t<T>(v)),
+                     tts::prec<T>());
+};

--- a/test/unit/complex/erfi.cpp
+++ b/test/unit/complex/erfi.cpp
@@ -72,3 +72,15 @@ TTS_CASE_WITH("Check behavior of erfi on wide",
     TTS_RELATIVE_EQUAL(ez.get(i), kyosu::erfi(z.get(i)), tts::prec<T>());
   }
 };
+
+//======================================================================================================================
+//== A masked call answers a complex where its argument was real, so the lanes the condition rejects carry complex(v)
+//======================================================================================================================
+TTS_CASE_WITH("Check kyosu::erfi over a masked real", kyosu::real_types, tts::randoms(-1.0, 1.0))
+<typename T>(T v)
+{
+  auto cond = eve::is_ltz(v);
+
+  TTS_RELATIVE_EQUAL(kyosu::erfi[cond](v), kyosu::if_else(cond, kyosu::erfi(v), kyosu::complex_t<T>(v)),
+                     tts::prec<T>());
+};

--- a/test/unit/complex/faddeeva.cpp
+++ b/test/unit/complex/faddeeva.cpp
@@ -61,3 +61,15 @@ TTS_CASE_TPL("Check faddeeva", kyosu::real_types)
       << "i " << i << " -> " << inputs[i] << " -> " << faddeeva(inputs[i]) << "\n";
   }
 };
+
+//======================================================================================================================
+//== A masked call answers a complex where its argument was real, so the lanes the condition rejects carry complex(v)
+//======================================================================================================================
+TTS_CASE_WITH("Check kyosu::faddeeva over a masked real", kyosu::real_types, tts::randoms(-1.0, 1.0))
+<typename T>(T v)
+{
+  auto cond = eve::is_ltz(v);
+
+  TTS_RELATIVE_EQUAL(kyosu::faddeeva[cond](v), kyosu::if_else(cond, kyosu::faddeeva(v), kyosu::complex_t<T>(v)),
+                     tts::prec<T>());
+};

--- a/test/unit/complex/omega.cpp
+++ b/test/unit/complex/omega.cpp
@@ -87,3 +87,15 @@ TTS_CASE_TPL("Check peculiar values", kyosu::real_types)
     }
   }
 };
+
+//======================================================================================================================
+//== A masked call answers a complex where its argument was real, so the lanes the condition rejects carry complex(v)
+//======================================================================================================================
+TTS_CASE_WITH("Check kyosu::omega over a masked real", kyosu::real_types, tts::randoms(-10, 10))
+<typename T>(T v)
+{
+  auto cond = eve::is_ltz(v);
+
+  TTS_RELATIVE_EQUAL(kyosu::omega[cond](v), kyosu::if_else(cond, kyosu::omega(v), kyosu::complex_t<T>(v)),
+                     tts::prec<T>());
+};

--- a/test/unit/function/acsch.cpp
+++ b/test/unit/function/acsch.cpp
@@ -32,3 +32,15 @@ TTS_CASE_WITH("Check kyosu::acsch over quaternion",
   TTS_RELATIVE_EQUAL(kyosu::csch(lc), c, tts::prec<T>());
   TTS_RELATIVE_EQUAL(kyosu::csch(lq), q, 5e-2);
 };
+
+//======================================================================================================================
+//== A masked call answers a complex where its argument was real, so the lanes the condition rejects carry complex(v)
+//======================================================================================================================
+TTS_CASE_WITH("Check kyosu::acsch over a masked real", kyosu::real_types, tts::randoms(1.0, 10.0))
+<typename T>(T v)
+{
+  auto cond = eve::is_greater(v, T(5));
+
+  TTS_RELATIVE_EQUAL(kyosu::acsch[cond](v), kyosu::if_else(cond, kyosu::acsch(v), kyosu::complex_t<T>(v)),
+                     tts::prec<T>());
+};

--- a/test/unit/function/asech.cpp
+++ b/test/unit/function/asech.cpp
@@ -32,3 +32,15 @@ TTS_CASE_WITH("Check kyosu::asech over quaternion",
   TTS_RELATIVE_EQUAL(kyosu::sech(lc), c, tts::prec_low<T>());
   TTS_RELATIVE_EQUAL(kyosu::sech(lq), q, tts::prec_low<T>());
 };
+
+//======================================================================================================================
+//== A masked call answers a complex where its argument was real, so the lanes the condition rejects carry complex(v)
+//======================================================================================================================
+TTS_CASE_WITH("Check kyosu::asech over a masked real", kyosu::real_types, tts::randoms(0.5, 2.0))
+<typename T>(T v)
+{
+  auto cond = eve::is_greater(v, T(1));
+
+  TTS_RELATIVE_EQUAL(kyosu::asech[cond](v), kyosu::if_else(cond, kyosu::asech(v), kyosu::complex_t<T>(v)),
+                     tts::prec<T>());
+};

--- a/test/unit/function/asech.cpp
+++ b/test/unit/function/asech.cpp
@@ -36,10 +36,11 @@ TTS_CASE_WITH("Check kyosu::asech over quaternion",
 //======================================================================================================================
 //== A masked call answers a complex where its argument was real, so the lanes the condition rejects carry complex(v)
 //======================================================================================================================
-TTS_CASE_WITH("Check kyosu::asech over a masked real", kyosu::real_types, tts::randoms(0.5, 2.0))
+//== Away from 1, where asech is zero and its derivative diverges: a relative comparison there says nothing.
+TTS_CASE_WITH("Check kyosu::asech over a masked real", kyosu::real_types, tts::randoms(1.5, 4.0))
 <typename T>(T v)
 {
-  auto cond = eve::is_greater(v, T(1));
+  auto cond = eve::is_greater(v, T(2.75));
 
   TTS_RELATIVE_EQUAL(kyosu::asech[cond](v), kyosu::if_else(cond, kyosu::asech(v), kyosu::complex_t<T>(v)),
                      tts::prec<T>());

--- a/test/unit/function/exp_i.cpp
+++ b/test/unit/function/exp_i.cpp
@@ -29,3 +29,15 @@ TTS_CASE_WITH("Check kyosu::exp_i over cayley_dickson",
   auto q = qe_t(r, i, j, k);
   TTS_RELATIVE_EQUAL(kyosu::exp_i(q), kyosu::exp(ii * q), tts::prec<T>());
 };
+
+//======================================================================================================================
+//== A masked call answers a complex where its argument was real, so the lanes the condition rejects carry complex(v)
+//======================================================================================================================
+TTS_CASE_WITH("Check kyosu::exp_i over a masked real", kyosu::real_types, tts::randoms(0.5, 2.0))
+<typename T>(T v)
+{
+  auto cond = eve::is_greater(v, T(1));
+
+  TTS_RELATIVE_EQUAL(kyosu::exp_i[cond](v), kyosu::if_else(cond, kyosu::exp_i(v), kyosu::complex_t<T>(v)),
+                     tts::prec<T>());
+};

--- a/test/unit/function/expx2.cpp
+++ b/test/unit/function/expx2.cpp
@@ -26,3 +26,15 @@ TTS_CASE_WITH("Check kyosu::expx2 over quaternion",
   auto q = qe_t(r, i, j, k);
   TTS_RELATIVE_EQUAL(kyosu::expx2(q), kyosu::exp(kyosu::sqr(q)), tts::prec<T>());
 };
+
+//======================================================================================================================
+//== A masked call answers a complex where its argument was real, so the lanes the condition rejects carry complex(v)
+//======================================================================================================================
+TTS_CASE_WITH("Check kyosu::expx2 over a masked real", kyosu::real_types, tts::randoms(0.5, 2.0))
+<typename T>(T v)
+{
+  auto cond = eve::is_greater(v, T(1));
+
+  TTS_RELATIVE_EQUAL(kyosu::expx2[cond](v), kyosu::if_else(cond, kyosu::expx2(v), kyosu::complex_t<T>(v)),
+                     tts::prec<T>());
+};

--- a/test/unit/function/muli.cpp
+++ b/test/unit/function/muli.cpp
@@ -51,3 +51,15 @@ TTS_CASE_WITH("Check kyosu::muli over octonion",
   using type = kyosu::octonion_t<T>;
   TTS_EQUAL(kyosu::muli(type(r, i, j, k, l, li, lj, lk)), kyosu::i(kyosu::as<T>()) * type(r, i, j, k, l, li, lj, lk));
 };
+
+//======================================================================================================================
+//== A masked call answers a complex where its argument was real, so the lanes the condition rejects carry complex(v)
+//======================================================================================================================
+TTS_CASE_WITH("Check kyosu::muli over a masked real", kyosu::real_types, tts::randoms(-10, 10))
+<typename T>(T v)
+{
+  auto cond = eve::is_ltz(v);
+
+  TTS_RELATIVE_EQUAL(kyosu::muli[cond](v), kyosu::if_else(cond, kyosu::muli(v), kyosu::complex_t<T>(v)),
+                     tts::prec<T>());
+};

--- a/test/unit/function/mulmi.cpp
+++ b/test/unit/function/mulmi.cpp
@@ -51,3 +51,15 @@ TTS_CASE_WITH("Check kyosu::mulmi over octonion",
   using type = kyosu::octonion_t<T>;
   TTS_EQUAL(kyosu::mulmi(type(r, i, j, k, l, li, lj, lk)), kyosu::mi(kyosu::as<T>()) * type(r, i, j, k, l, li, lj, lk));
 };
+
+//======================================================================================================================
+//== A masked call answers a complex where its argument was real, so the lanes the condition rejects carry complex(v)
+//======================================================================================================================
+TTS_CASE_WITH("Check kyosu::mulmi over a masked real", kyosu::real_types, tts::randoms(-10, 10))
+<typename T>(T v)
+{
+  auto cond = eve::is_ltz(v);
+
+  TTS_RELATIVE_EQUAL(kyosu::mulmi[cond](v), kyosu::if_else(cond, kyosu::mulmi(v), kyosu::complex_t<T>(v)),
+                     tts::prec<T>());
+};

--- a/test/unit/function/tricomi.cpp
+++ b/test/unit/function/tricomi.cpp
@@ -67,3 +67,15 @@ TTS_CASE_TPL("Check tricomi ", kyosu::scalar_real_types)
   test(1000.0, 2.0, 2.5, res[18], 18);
   test(100.0, 10.0, 10.0, res[19], 19);
 };
+
+//======================================================================================================================
+//== A masked call answers a complex where its argument was real, so the lanes the condition rejects carry complex(v)
+//======================================================================================================================
+TTS_CASE_WITH("Check kyosu::tricomi over a masked real", kyosu::real_types, tts::randoms(1.0, 2.0))
+<typename T>(T v)
+{
+  auto cond = eve::is_greater(v, T(1.5));
+
+  TTS_RELATIVE_EQUAL(kyosu::tricomi[cond](v, T(1), T(1)),
+                     kyosu::if_else(cond, kyosu::tricomi(v, T(1), T(1)), kyosu::complex_t<T>(v)), tts::prec<T>());
+};

--- a/test/unit/function/xi.cpp
+++ b/test/unit/function/xi.cpp
@@ -22,3 +22,14 @@ TTS_CASE_WITH("Check kyosu::xi over real", kyosu::real_types, tts::randoms(-10, 
   TTS_IEEE_EQUAL(kyosu::xi(kyosu::nan(kyosu::as(kyosu::complex(pi)))), kyosu::fnan(kyosu::as(kyosu::complex(pi))));
   TTS_IEEE_EQUAL(kyosu::xi(kyosu::cinf(kyosu::as(kyosu::complex(pi)))), kyosu::fnan(kyosu::as(kyosu::complex(pi))));
 };
+
+//======================================================================================================================
+//== A masked call answers a complex where its argument was real, so the lanes the condition rejects carry complex(v)
+//======================================================================================================================
+TTS_CASE_WITH("Check kyosu::xi over a masked real", kyosu::real_types, tts::randoms(-10, 10))
+<typename T>(T v)
+{
+  auto cond = eve::is_ltz(v);
+
+  TTS_RELATIVE_EQUAL(kyosu::xi[cond](v), kyosu::if_else(cond, kyosu::xi(v), kyosu::complex_t<T>(v)), tts::prec<T>());
+};

--- a/test/unit/function/zeta.cpp
+++ b/test/unit/function/zeta.cpp
@@ -19,3 +19,15 @@ TTS_CASE_WITH("Check kyosu::xi over real", kyosu::real_types, tts::randoms(-10, 
   TTS_RELATIVE_EQUAL(kyosu::zeta(T(3)), kyosu::complex(T(1.2020569031595942854)), pr);
   TTS_RELATIVE_EQUAL(kyosu::zeta(T(4)), kyosu::complex(pi * pi * pi * pi / 90), pr);
 };
+
+//======================================================================================================================
+//== A masked call answers a complex where its argument was real, so the lanes the condition rejects carry complex(v)
+//======================================================================================================================
+TTS_CASE_WITH("Check kyosu::zeta over a masked real", kyosu::real_types, tts::randoms(-10, 10))
+<typename T>(T v)
+{
+  auto cond = eve::is_ltz(v);
+
+  TTS_RELATIVE_EQUAL(kyosu::zeta[cond](v), kyosu::if_else(cond, kyosu::zeta(v), kyosu::complex_t<T>(v)),
+                     tts::prec<T>());
+};

--- a/test/unit/quaternion/slerp.cpp
+++ b/test/unit/quaternion/slerp.cpp
@@ -57,3 +57,38 @@ TTS_CASE_WITH("Check that slerp takes the shortest arc",
   // q and -q are the same rotation, so both must be interpolated the same way.
   TTS_RELATIVE_EQUAL(kyosu::slerp(z0, z1, T(0.5)), kyosu::slerp(z0, -z1, T(0.5)), tts::prec<T>());
 };
+
+//======================================================================================================================
+//== A masked call answers a complex where its argument was real, so the lanes the condition rejects carry complex(v)
+//======================================================================================================================
+TTS_CASE_WITH("Check kyosu::slerp over a masked real",
+              kyosu::real_types,
+              tts::randoms(-2.0, 2.0),
+              tts::randoms(-2.0, 2.0),
+              tts::randoms(0.25, 0.75))
+<typename T>(T const& a, T const& b, T const& t)
+{
+  auto cond = eve::is_ltz(a);
+
+  TTS_RELATIVE_EQUAL(kyosu::slerp[cond](a, b, t), kyosu::if_else(cond, kyosu::slerp(a, b, t), kyosu::complex_t<T>(a)),
+                     tts::prec<T>());
+};
+
+//======================================================================================================================
+//== The same call on quaternions, where the argument and the answer share a type and the interpolation is a real one
+//======================================================================================================================
+TTS_CASE_WITH("Check kyosu::slerp[cond] over quaternions",
+              kyosu::simd_real_types,
+              tts::randoms(-1., +1.),
+              tts::randoms(-1., +1.),
+              tts::randoms(-1., +1.),
+              tts::randoms(-1., +1.))
+<typename T>(T const& a, T const& b, T const& c, T const& d)
+{
+  auto z0 = kyosu::sign(kyosu::quaternion_t<T>(a, b, c, d));
+  auto z1 = kyosu::sign(kyosu::quaternion_t<T>(d, c, b, a));
+  auto cond = eve::is_even(eve::iota(eve::as<T>()));
+
+  TTS_RELATIVE_EQUAL(kyosu::slerp[cond](z0, z1, T(0.5)), kyosu::if_else(cond, kyosu::slerp(z0, z1, T(0.5)), z0),
+                     tts::prec<T>());
+};


### PR DESCRIPTION
A masked call gives back its first argument on the lanes the condition rejects, so that argument has to already be of the type the call returns. Where kyosu answers a complex to a real, the two differ, and what eve reaches for then is its own convert, which knows nothing of Cayley-Dickson: the name resolves to a variable, so no argument-dependent lookup can bring kyosu's convert into that call.

Twenty-two functions already work around it one at a time, with a conditional overload that complexifies the fallback before eve sees it - sqrt, acos and log among them, which is why the path looked healthy. kyosu::elementwise_callable does it once, guarded by what the call actually answers rather than by a list: abs and arg answer a real, so nothing is promoted there. erfi is wired to it here, with the fourteen masked cases that found the hole; the thirty-one functions in the same position follow once this holds.