### PR TITLE
Include through the path, not from the directory

### DIFF
--- a/include/kyosu/constants/j.hpp
+++ b/include/kyosu/constants/j.hpp
@@ -7,7 +7,7 @@
 //======================================================================================================================
 #pragma once
 
-#include "kyosu/types/traits.hpp"
+#include <kyosu/types/traits.hpp>
 #include <kyosu/details/callable.hpp>
 
 namespace kyosu

--- a/test/unit/function/rot_axis.cpp
+++ b/test/unit/function/rot_axis.cpp
@@ -5,7 +5,7 @@
   SPDX-License-Identifier: BSL-1.0
 */
 //======================================================================================================================
-#include "test.hpp"
+#include <test.hpp>
 #include <kyosu/kyosu.hpp>
 
 TTS_CASE_WITH("Check behavior of rot_axis on wide",

--- a/test/unit/function/to_polar.cpp
+++ b/test/unit/function/to_polar.cpp
@@ -5,7 +5,7 @@
   SPDX-License-Identifier: BSL-1.0
 **/
 //==================================================================================================
-#include "test.hpp"
+#include <test.hpp>
 #include <kyosu/kyosu.hpp>
 
 TTS_CASE_WITH("Check behavior of to_polar on wide",

--- a/test/unit/function/to_polarpi.cpp
+++ b/test/unit/function/to_polarpi.cpp
@@ -5,7 +5,7 @@
   SPDX-License-Identifier: BSL-1.0
 **/
 //==================================================================================================
-#include "test.hpp"
+#include <test.hpp>
 #include <kyosu/kyosu.hpp>
 
 TTS_CASE_WITH("Check behavior of to_polarpi on wide",

--- a/test/unit/infra/constants/base.cpp
+++ b/test/unit/infra/constants/base.cpp
@@ -5,7 +5,7 @@
   SPDX-License-Identifier: BSL-1.0
 */
 //======================================================================================================================
-#include "test.hpp"
+#include <test.hpp>
 #include <kyosu/kyosu.hpp>
 
 TTS_CASE_TPL("Generate basic constants on real types", kyosu::real_types)

--- a/test/unit/infra/parts/real.cpp
+++ b/test/unit/infra/parts/real.cpp
@@ -5,8 +5,8 @@
   SPDX-License-Identifier: BSL-1.0
 */
 //======================================================================================================================
-#include "kyosu/types/octonion.hpp"
-#include "tts/tools/typename.hpp"
+#include <kyosu/types/octonion.hpp>
+#include <tts/tools/typename.hpp>
 #include <kyosu/kyosu.hpp>
 #include <test.hpp>
 

--- a/test/unit/quaternion/align.cpp
+++ b/test/unit/quaternion/align.cpp
@@ -5,7 +5,7 @@
   SPDX-License-Identifier: BSL-1.0
 */
 //======================================================================================================================
-#include "test.hpp"
+#include <test.hpp>
 #include <kyosu/kyosu.hpp>
 
 TTS_CASE_WITH("Check behavior of align on wide",

--- a/test/unit/quaternion/rotate_vec.cpp
+++ b/test/unit/quaternion/rotate_vec.cpp
@@ -5,7 +5,7 @@
   SPDX-License-Identifier: BSL-1.0
 */
 //======================================================================================================================
-#include "test.hpp"
+#include <test.hpp>
 #include <kyosu/kyosu.hpp>
 
 TTS_CASE_WITH("Check behavior of rotate_vec on wide",

--- a/test/unit/quaternion/slerp.cpp
+++ b/test/unit/quaternion/slerp.cpp
@@ -5,7 +5,7 @@
   SPDX-License-Identifier: BSL-1.0
 */
 //======================================================================================================================
-#include "test.hpp"
+#include <test.hpp>
 #include <kyosu/kyosu.hpp>
 
 TTS_CASE_WITH("Check that slerp reaches both ends of the arc",

--- a/test/unit/quaternion/to_angle_axis.cpp
+++ b/test/unit/quaternion/to_angle_axis.cpp
@@ -5,7 +5,7 @@
   SPDX-License-Identifier: BSL-1.0
 */
 //======================================================================================================================
-#include "test.hpp"
+#include <test.hpp>
 #include <kyosu/kyosu.hpp>
 
 TTS_CASE_WITH("Check behavior of from_angle_axis on wide",

--- a/test/unit/quaternion/to_cylindrical.cpp
+++ b/test/unit/quaternion/to_cylindrical.cpp
@@ -5,7 +5,7 @@
   SPDX-License-Identifier: BSL-1.0
 */
 //======================================================================================================================
-#include "test.hpp"
+#include <test.hpp>
 #include <kyosu/kyosu.hpp>
 
 TTS_CASE_WITH("Check behavior of to_cylindrical on wide",

--- a/test/unit/quaternion/to_cylindrospherical.cpp
+++ b/test/unit/quaternion/to_cylindrospherical.cpp
@@ -5,7 +5,7 @@
   SPDX-License-Identifier: BSL-1.0
 */
 //======================================================================================================================
-#include "test.hpp"
+#include <test.hpp>
 #include <kyosu/kyosu.hpp>
 
 TTS_CASE_WITH("Check behavior of to_cylindrospherical on wide",

--- a/test/unit/quaternion/to_euler.cpp
+++ b/test/unit/quaternion/to_euler.cpp
@@ -5,7 +5,7 @@
   SPDX-License-Identifier: BSL-1.0
 */
 //======================================================================================================================
-#include "test.hpp"
+#include <test.hpp>
 #include <kyosu/kyosu.hpp>
 
 TTS_CASE_WITH("Check behavior of rotate_vec on wide",

--- a/test/unit/quaternion/to_multipolar.cpp
+++ b/test/unit/quaternion/to_multipolar.cpp
@@ -5,7 +5,7 @@
   SPDX-License-Identifier: BSL-1.0
 */
 //======================================================================================================================
-#include "test.hpp"
+#include <test.hpp>
 #include <kyosu/kyosu.hpp>
 
 TTS_CASE_WITH("Check behavior of from_multipolar on wide",

--- a/test/unit/quaternion/to_rotation_matrix.cpp
+++ b/test/unit/quaternion/to_rotation_matrix.cpp
@@ -5,7 +5,7 @@
   SPDX-License-Identifier: BSL-1.0
 */
 //======================================================================================================================
-#include "test.hpp"
+#include <test.hpp>
 #include <kyosu/kyosu.hpp>
 
 template<typename T> auto prod(auto m, std::array<T, 3> const& v)

--- a/test/unit/quaternion/to_semipolar.cpp
+++ b/test/unit/quaternion/to_semipolar.cpp
@@ -5,7 +5,7 @@
   SPDX-License-Identifier: BSL-1.0
 */
 //======================================================================================================================
-#include "test.hpp"
+#include <test.hpp>
 #include <kyosu/kyosu.hpp>
 
 TTS_CASE_WITH("Check behavior of to_semipolar on wide",

--- a/test/unit/quaternion/to_spherical.cpp
+++ b/test/unit/quaternion/to_spherical.cpp
@@ -5,7 +5,7 @@
   SPDX-License-Identifier: BSL-1.0
 */
 //======================================================================================================================
-#include "test.hpp"
+#include <test.hpp>
 #include <kyosu/kyosu.hpp>
 
 TTS_CASE_WITH("Check behavior of to_spherical on wide",


### PR DESCRIPTION
Quotes said these headers sat beside the file including them, and none of them did: test.hpp lives at the
root of the test tree, and the other two name an install path. The rest of the tree had already settled on
angle brackets, 257 files against 15.
