### PR TITLE
Resolve EVE's dependency headers under both spellings

### DIFF
--- a/include/kyosu/details/decorators.hpp
+++ b/include/kyosu/details/decorators.hpp
@@ -6,7 +6,13 @@
 */
 //======================================================================================================================
 #pragma once
+// TODO: drop the guard and keep <eve/deps/raberu.hpp> alone once the EVE pin reaches a commit that
+// carries it, which is what #262 does. Same move as the kumi header in types/traits.hpp.
+#if __has_include(<eve/deps/raberu.hpp>)
+#include <eve/deps/raberu.hpp>
+#else
 #include <eve/detail/raberu.hpp>
+#endif
 #include <eve/module/core/decorator/core.hpp>
 
 namespace kyosu

--- a/include/kyosu/types/traits.hpp
+++ b/include/kyosu/types/traits.hpp
@@ -7,7 +7,15 @@
 //======================================================================================================================
 #pragma once
 
-#include "eve/deps/kumi/tuple.hpp"
+// TODO: drop the guard and keep <eve/deps/kumi.hpp> alone as soon as the EVE pin in
+// cmake/dependencies.cmake reaches a commit that carries it, which is what #262 does. EVE moved its
+// vendored dependencies under deps/ and renamed them, and the integration tests build against EVE's
+// main whatever the pin says, so both spellings have to resolve in the meantime.
+#if __has_include(<eve/deps/kumi.hpp>)
+#include <eve/deps/kumi.hpp>
+#else
+#include <eve/deps/kumi/tuple.hpp>
+#endif
 #include <kyosu/types/helpers.hpp>
 #include <kyosu/details/decorators.hpp>
 #include <eve/as.hpp>


### PR DESCRIPTION
`main` fails on `integration / fetch-content` alone: that job builds against EVE's main whatever the pins say, and two headers here name paths EVE has moved, `eve/deps/kumi/tuple.hpp` and `eve/detail/raberu.hpp`. Both spellings now resolve behind `__has_include`, so the sources build against EVE's main and against the pinned commit alike, which is checked locally in both directions.

Each guard carries a TODO naming what removes it: the EVE pin reaching a commit that carries the new headers, which is #262. That pull request stays what it is, the pin bump, and waits on #265; this one only takes `main` out of the red in the meantime.