### PR TITLE
Move to copacabana v8

### DIFF
--- a/.github/matrices/linux-no-pch.yml
+++ b/.github/matrices/linux-no-pch.yml
@@ -10,6 +10,8 @@ runs-on: ubuntu-latest
 image: v10
 container-options: -u root
 configs: [Debug]
+## Building alone already takes forty minutes here, and the tests now run on top of it.
+timeout: 120
 build-targets: doc.exe
 rows:
   - { name: "gcc, no PCH", preset: "gcc-no-pch", test: false }

--- a/.github/matrices/linux.yml
+++ b/.github/matrices/linux.yml
@@ -8,6 +8,8 @@ runs-on: ubuntu-latest
 image: v10
 container-options: -u root
 configs: [Debug]
+## Building alone already takes forty minutes here, and the tests now run on top of it.
+timeout: 120
 build-targets: doc.exe unit.exe
 test-targets: ^(doc|unit).*
 rows:

--- a/.github/matrices/macos.yml
+++ b/.github/matrices/macos.yml
@@ -6,6 +6,8 @@
 ## Read by copacabana's matrix.yml: the macOS jobs, Debug only, the documentation examples and the units in one build.
 runs-on: macos-14
 configs: [Debug]
+## Building alone already takes forty minutes here, and the tests now run on top of it.
+timeout: 120
 build-targets: doc.exe unit.exe
 test-targets: ^(doc|unit).*
 rows:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Configure CMake and Build
-        uses: jfalcou/copacabana/.github/actions/config@05d0796125e284daa16d9a4f6424c58f98a2bb5a # v7
+        uses: jfalcou/copacabana/.github/actions/config@44053e713b1b57329ccbcbb8878c839024bf19ee # v8
         with:
           config: Release
           preset: ${{ matrix.compiler.preset }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
   ##################################################################################################
   precommit:
     name: Meta Checks
-    uses: jfalcou/copacabana/.github/workflows/precommit.yml@05d0796125e284daa16d9a4f6424c58f98a2bb5a # v7
+    uses: jfalcou/copacabana/.github/workflows/precommit.yml@44053e713b1b57329ccbcbb8878c839024bf19ee # v8
 
   ##################################################################################################
   ## Unit Tests
@@ -27,7 +27,7 @@ jobs:
   linux-tests:
     name: Linux
     needs: precommit
-    uses: jfalcou/copacabana/.github/workflows/matrix.yml@05d0796125e284daa16d9a4f6424c58f98a2bb5a # v7
+    uses: jfalcou/copacabana/.github/workflows/matrix.yml@44053e713b1b57329ccbcbb8878c839024bf19ee # v8
     with:
       file: .github/matrices/linux.yml
 
@@ -35,14 +35,14 @@ jobs:
   no-pch-tests:
     name: Linux
     needs: precommit
-    uses: jfalcou/copacabana/.github/workflows/matrix.yml@05d0796125e284daa16d9a4f6424c58f98a2bb5a # v7
+    uses: jfalcou/copacabana/.github/workflows/matrix.yml@44053e713b1b57329ccbcbb8878c839024bf19ee # v8
     with:
       file: .github/matrices/linux-no-pch.yml
 
   macos-tests:
     name: MacOS
     needs: precommit
-    uses: jfalcou/copacabana/.github/workflows/matrix.yml@05d0796125e284daa16d9a4f6424c58f98a2bb5a # v7
+    uses: jfalcou/copacabana/.github/workflows/matrix.yml@44053e713b1b57329ccbcbb8878c839024bf19ee # v8
     with:
       file: .github/matrices/macos.yml
 
@@ -51,7 +51,7 @@ jobs:
   ##################################################################################################
   sanitizer-tests:
     name: Sanitizers
-    uses: jfalcou/copacabana/.github/workflows/sanitizers.yml@05d0796125e284daa16d9a4f6424c58f98a2bb5a # v7
+    uses: jfalcou/copacabana/.github/workflows/sanitizers.yml@44053e713b1b57329ccbcbb8878c839024bf19ee # v8
     with:
       build-targets: unit.exe doc.exe
       test-targets: unit|doc
@@ -61,7 +61,7 @@ jobs:
   ##################################################################################################
   coverage-report:
     name: Coverage
-    uses: jfalcou/copacabana/.github/workflows/coverage.yml@05d0796125e284daa16d9a4f6424c58f98a2bb5a # v7
+    uses: jfalcou/copacabana/.github/workflows/coverage.yml@44053e713b1b57329ccbcbb8878c839024bf19ee # v8
     with:
       project: kyosu
       build-targets: kyosu-test

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -17,7 +17,7 @@ jobs:
   documentation:
     permissions:
       contents: write
-    uses: jfalcou/copacabana/.github/workflows/documentation.yml@05d0796125e284daa16d9a4f6424c58f98a2bb5a # v7
+    uses: jfalcou/copacabana/.github/workflows/documentation.yml@44053e713b1b57329ccbcbb8878c839024bf19ee # v8
     with:
       project: kyosu
       coverage: true

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   integration:
-    uses: jfalcou/copacabana/.github/workflows/integration.yml@05d0796125e284daa16d9a4f6424c58f98a2bb5a # v7
+    uses: jfalcou/copacabana/.github/workflows/integration.yml@44053e713b1b57329ccbcbb8878c839024bf19ee # v8
     with:
       project: kyosu
       cxx-compiler: g++-15

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -13,7 +13,7 @@ include(${CMAKE_CURRENT_LIST_DIR}/CPM.cmake)
 ##======================================================================================================================
 ## Retrieve dependencies
 ##======================================================================================================================
-CPMAddPackage ( NAME COPACABANA GITHUB_REPOSITORY jfalcou/copacabana  GIT_TAG v7)
+CPMAddPackage ( NAME COPACABANA GITHUB_REPOSITORY jfalcou/copacabana  GIT_TAG v8)
 CPMAddPackage ( NAME TTS   GITHUB_REPOSITORY jfalcou/tts
                 GIT_TAG main
                 OPTIONS "TTS_BUILD_TEST OFF"


### PR DESCRIPTION
The matrix ran no test from v7 on: a row saying nothing about `test` read as null, which GitHub compares equal to false. This pin is what brings the tests back, so the jobs of this repository run them again for the first time since 2026-09-03.

The matrices ask for two hours rather than the hour v8 gives by default: building alone takes forty minutes here, and the tests now run on top of it.