### PR TITLE
Add the compile-cost target and its workflow

### DIFF
--- a/.github/workflows/compile-cost.yml
+++ b/.github/workflows/compile-cost.yml
@@ -1,0 +1,28 @@
+##======================================================================================================================
+## Kyosu - Complex Without Complexes
+## Copyright : KYOSU Contributors & Maintainers
+## SPDX-License-Identifier: BSL-1.0
+##======================================================================================================================
+## What every test unit costs to compile: a push to main leaves the reference, a pull request reports the delta.
+name: KYOSU Compile Cost
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: kyosu-compile-cost-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  compile-cost:
+    ## Reading the reference off another run asks more than the contents scope the token defaults to.
+    permissions:
+      actions: read
+      contents: read
+    uses: jfalcou/copacabana/.github/workflows/compile-cost.yml@44053e713b1b57329ccbcbb8878c839024bf19ee # v8
+    with:
+      project: kyosu

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ copa_add_option(KYOSU_BUILD_DOCUMENTATION "Build Doxygen for KYOSU" OFF LABEL "D
 copa_add_option(KYOSU_ENABLE_SANITIZERS "Build tests with AddressSanitizer + UndefinedBehaviorSanitizer" OFF LABEL "Sanitizers")
 copa_add_option(KYOSU_ENABLE_COVERAGE "Build tests with code coverage instrumentation" OFF LABEL "Coverage")
 copa_add_option(KYOSU_BUILD_DEMOS "Build the interactive demos" OFF LABEL "Demos")
+copa_add_option(KYOSU_COMPILE_COST "Measure what every test unit costs to compile" OFF)
 copa_project_version(MAJOR 0 MINOR 1 PATCH 0 REPOSITORY https://github.com/jfalcou/kyosu)
 
 ##======================================================================================================================
@@ -83,6 +84,11 @@ if(KYOSU_BUILD_TEST)
   # After the test targets exist, so the coverage targets can depend on them
   if(KYOSU_ENABLE_COVERAGE)
     copa_setup_coverage(kyosu_docs)
+  endif()
+
+  # clang only: -fproc-stat-report is its flag. After the test targets, as the measurement rebuilds them.
+  if(KYOSU_COMPILE_COST)
+    copa_setup_compile_cost(kyosu_test)
   endif()
 endif()
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -32,6 +32,7 @@
     { "name": "clang-avx2"   , "inherits": ["unix-base"], "cacheVariables": { "CMAKE_CXX_COMPILER": "clang++-20", "CMAKE_CXX_FLAGS": "-O0 -DEVE_NO_FORCEINLINE -mavx2" } },
 
     { "name": "no-pch"       , "hidden": true, "cacheVariables": { "KYOSU_USE_PCH": "OFF" } },
+    { "name": "compile-cost" , "hidden": true, "cacheVariables": { "KYOSU_COMPILE_COST": "ON" } },
     { "name": "gcc-no-pch"     , "inherits": ["gcc"  , "no-pch"] },
 
     { "name": "sanitize"     , "hidden": true, "cacheVariables": { "KYOSU_ENABLE_SANITIZERS": "ON" } },
@@ -40,6 +41,7 @@
     { "name": "clang-sanitize" , "inherits": ["clang", "sanitize"] },
     { "name": "gcc-coverage"   , "inherits": ["gcc"  , "coverage"] },
     { "name": "clang-coverage" , "inherits": ["clang", "coverage"] },
+    { "name": "clang-compile-cost" , "inherits": ["clang", "no-pch", "compile-cost"] },
 
     { "name": "gcc-demos"    , "inherits": ["unix-base"], "cacheVariables": { "CMAKE_CXX_COMPILER": "g++-15"    , "KYOSU_BUILD_DEMOS": "ON", "KYOSU_BUILD_TEST": "OFF" } },
     { "name": "clang-demos"  , "inherits": ["unix-base"], "cacheVariables": { "CMAKE_CXX_COMPILER": "clang++-20", "KYOSU_BUILD_DEMOS": "ON", "KYOSU_BUILD_TEST": "OFF" } },
@@ -69,6 +71,7 @@
     { "name": "clang-sanitize"    , "inherits": "base-build", "configurePreset": "clang-sanitize"    },
     { "name": "gcc-coverage"      , "inherits": "base-build", "configurePreset": "gcc-coverage"      },
     { "name": "clang-coverage"    , "inherits": "base-build", "configurePreset": "clang-coverage"    },
+    { "name": "clang-compile-cost", "inherits": "base-build", "configurePreset": "clang-compile-cost" },
     { "name": "gcc-bench"          , "inherits": "base-build", "configurePreset": "gcc-bench"          },
     { "name": "clang-bench"        , "inherits": "base-build", "configurePreset": "clang-bench"        },
     { "name": "clang-macos"       , "inherits": "base-build", "configurePreset": "clang-macos"        },


### PR DESCRIPTION
The figures only mean something under the preset the CI runs, so `clang-compile-cost` inherits `clang`, and `no-pch` as well: the unit tests build behind a precompiled header, whose cost would otherwise be most of what the report shows.

Nothing on `main` has left a reference artifact yet, so this first run reports absolute figures and says the delta is missing.
