### PR TITLE
Give main its nightly matrix run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,12 @@
 ##======================================================================================================================
 name: Unit Tests
 on:
+  ## Main gets the matrix once a night rather than on every merge: a run of its own queued behind each merge held
+  ## the pull requests back. 00:35 UTC, one rung of the fleet's 45 minute ladder, which starts at 00:35 and
+  ## never lands on the hour every other scheduled workflow on the platform asks for. kyosu opens it and polyfloat
+  ## sits in its middle, the two heaviest matrices taking the emptiest slots.
+  schedule:
+    - cron: '35 0 * * *'
   pull_request:
     branches:
       - main


### PR DESCRIPTION
`main` was the only branch nothing measured: the matrix ran on pull requests alone, so a merge could break it and nobody would know until the next pull request paid for it. A schedule is what the rest of the fleet uses, rather than a trigger on push to `main`, whose own run queues behind every merge and holds the pull requests back.

03:10 UTC, off the round hour the whole platform asks for, and off the slots the others hold: 01:20 for tts, kumi and raberu, 01:40 for fluxion, 02:20 for spy, 03:50 for polyfloat.
