### PR TITLE
Give every navigation tab a page of its own

### DIFF
--- a/doc/layout.xml
+++ b/doc/layout.xml
@@ -3,13 +3,13 @@
   <!-- Navigation index tabs for HTML output -->
   <navindex>
     <tab type="mainpage" visible="yes" title=""/>
-    <tab type="usergroup" visible="yes" title="Tutorials">
+    <tab type="usergroup" visible="yes" title="Tutorials" url="@ref setup">
       <tab type="user" url="@ref setup"                title="Installation &amp; Quick Start"/>
-      <tab type="usergroup" visible="yes" title="Getting Started">
+      <tab type="usergroup" visible="yes" title="Getting Started" url="@ref tutorial-complex">
         <tab type="user" url="@ref tutorial-complex"    title="Complex Numbers"/>
         <tab type="user" url="@ref tutorial-simd"       title="Many Values At Once"/>
       </tab>
-      <tab type="usergroup" visible="yes" title="Past The Complex Numbers">
+      <tab type="usergroup" visible="yes" title="Past The Complex Numbers" url="@ref tutorial-quaternion">
         <tab type="user" url="@ref tutorial-quaternion" title="Quaternions"/>
         <tab type="user" url="@ref tutorial-rotation"   title="Rotations"/>
         <tab type="user" url="@ref tutorial-beyond"     title="Octonions and Beyond"/>
@@ -17,7 +17,7 @@
       <tab type="user" url="@ref tutorial-options"     title="Options"/>
     </tab>
 
-    <tab type="usergroup" visible="yes" title="Reference Documentation">
+    <tab type="usergroup" visible="yes" title="Reference Documentation" url="@ref types">
       <tab type="user" url="@ref types" title="Types"/>
       <tab type="user" url="@ref constants" title="Constants"/>
       <tab type="usergroup" url="@ref kyosu_functions" visible="yes" title="Functions">
@@ -28,7 +28,7 @@
       <tab type="user" url="@ref kyosu_traits" title="Traits"/>
       <tab type="concepts" visible="yes" title=""/>
     </tab>
-    <tab type="usergroup" visible="yes" title="Informations">
+    <tab type="usergroup" visible="yes" title="Informations" url="@ref math_background">
       <tab type="user" url="@ref math_background" title="Mathematical Background"/>
       <tab type="user" url="@ref biblio"          title="Bibliography"/>
       <tab type="user" url="@ref changelog"       title="Changelog"/>


### PR DESCRIPTION
A container tab carrying no `url` is served as `usergroupN.html`, numbered by position, so inserting an entry moves what an existing link points to. Every container now names a page, the way kumi settled it in jfalcou/kumi#251.

The commit is marked `[no ci]`, so nothing reports and the barrier never lifts. The documentation was rebuilt locally in its place: no doxygen warning, so no reference dangles, and no `usergroup*.html` is left in the output.
