### PR TITLE
Fetch TTS where its option exists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,6 @@
 cmake_minimum_required(VERSION 3.22)
 project(kyosu LANGUAGES CXX)
 include(${PROJECT_SOURCE_DIR}/cmake/dependencies.cmake)
-include(${PROJECT_SOURCE_DIR}/cmake/compiler.cmake)
 
 ##======================================================================================================================
 
@@ -70,16 +69,17 @@ if(KYOSU_BUILD_DOCUMENTATION)
 endif()
 
 ##======================================================================================================================
-## Setup PCH
-##======================================================================================================================
-copa_setup_pch( TARGET kyosu        INTERFACES  kyosu_test  HEADERS include/kyosu/kyosu.hpp)
-copa_setup_pch( TARGET kyosu_doc    INTERFACES  kyosu_docs  HEADERS include/kyosu/kyosu.hpp)
-copa_setup_pch( TARGET kyosu_bench  INTERFACES  kyosu_bench HEADERS include/kyosu/kyosu.hpp)
-
-##======================================================================================================================
 ## Tests setup
 ##======================================================================================================================
 if(KYOSU_BUILD_TEST)
+  CPMGetPackage(TTS)
+  include(${PROJECT_SOURCE_DIR}/cmake/compiler.cmake)
+
+  ## After compiler.cmake, which declares the interfaces the precompiled headers are attached to.
+  copa_setup_pch( TARGET kyosu        INTERFACES  kyosu_test  HEADERS include/kyosu/kyosu.hpp)
+  copa_setup_pch( TARGET kyosu_doc    INTERFACES  kyosu_docs  HEADERS include/kyosu/kyosu.hpp)
+  copa_setup_pch( TARGET kyosu_bench  INTERFACES  kyosu_bench HEADERS include/kyosu/kyosu.hpp)
+
   if(KYOSU_ENABLE_SANITIZERS)
     copa_setup_sanitizers(kyosu_docs ENABLE_ASAN ENABLE_UBSAN)
   endif()

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -20,12 +20,14 @@ include(${CMAKE_CURRENT_LIST_DIR}/CPM.cmake)
 CPMAddPackage ( NAME COPACABANA GITHUB_REPOSITORY jfalcou/copacabana  GIT_TAG v8)
 CPMDeclarePackage ( TTS   NAME TTS   GITHUB_REPOSITORY jfalcou/tts
                     GIT_TAG main
+                    SYSTEM YES
                     OPTIONS "TTS_BUILD_TEST OFF"
                             "TTS_BUILD_DOCUMENTATION OFF"
                             "TTS_QUIET ON"
                   )
 CPMAddPackage ( NAME EVE   GITHUB_REPOSITORY jfalcou/eve
                 GIT_TAG main
+                SYSTEM YES
                 OPTIONS "EVE_BUILD_TEST OFF"
                         "EVE_BUILD_BENCHMARKS OFF"
                         "EVE_BUILD_DOCUMENTATION OFF"

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -12,14 +12,18 @@ include(${CMAKE_CURRENT_LIST_DIR}/CPM.cmake)
 
 ##======================================================================================================================
 ## Retrieve dependencies
+##
+## This file runs before the project can declare an option, copa_add_option arriving with copacabana, so a package
+## wanted only under an option is declared here and fetched after the options, in CMakeLists.txt. EVE stays
+## unconditional: the exported target links eve::eve, so it is needed by an install without tests.
 ##======================================================================================================================
 CPMAddPackage ( NAME COPACABANA GITHUB_REPOSITORY jfalcou/copacabana  GIT_TAG v8)
-CPMAddPackage ( NAME TTS   GITHUB_REPOSITORY jfalcou/tts
-                GIT_TAG main
-                OPTIONS "TTS_BUILD_TEST OFF"
-                        "TTS_BUILD_DOCUMENTATION OFF"
-                        "TTS_QUIET ON"
-              )
+CPMDeclarePackage ( TTS   NAME TTS   GITHUB_REPOSITORY jfalcou/tts
+                    GIT_TAG main
+                    OPTIONS "TTS_BUILD_TEST OFF"
+                            "TTS_BUILD_DOCUMENTATION OFF"
+                            "TTS_QUIET ON"
+                  )
 CPMAddPackage ( NAME EVE   GITHUB_REPOSITORY jfalcou/eve
                 GIT_TAG main
                 OPTIONS "EVE_BUILD_TEST OFF"


### PR DESCRIPTION
`cmake/dependencies.cmake` runs before `copa_add_option` exists, so a package guarded there on an
option is skipped on the first configure of a fresh clone. TTS is now declared there and fetched
under the option in `CMakeLists.txt`, the form copacabana carries since its `Fix #113`. EVE stays
unconditional, the exported target linking `eve::eve`.

`cmake/compiler.cmake` and the three `copa_setup_pch` calls move into the test block with it,
nothing outside reading the interfaces they declare. The second commit marks TTS and EVE as
`SYSTEM`, so a warning introduced upstream cannot break this repository's build.
